### PR TITLE
Fix/11 reservation status

### DIFF
--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
@@ -8,12 +8,7 @@ import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidateStatus;
 
-import java.util.Objects;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Entity
 @Getter
@@ -25,7 +20,7 @@ public class Reservation extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    //낙관적 락을 위한 버전 추가(추후 분산 락으로 수정예정)
+    // 낙관적 락을 위한 버전 추가(추후 분산 락으로 수정 예정)
     @Version
     private Long version;
 
@@ -50,16 +45,16 @@ public class Reservation extends BaseEntity {
     }
 
     public void addCandidate(ReservationCandidate candidate) {
-        validateStatus(ReservationStatus.PENDING);
+        validateStatus(ReservationStatus.AVAILABLE);
         this.candidates.add(candidate);
     }
 
     public void removeCandidate(ReservationCandidate candidate) {
-        validateStatus(ReservationStatus.PENDING);
+        validateStatus(ReservationStatus.AVAILABLE);
         this.candidates.remove(candidate);
     }
 
-    // 예약 생성
+    // 예약 생성: 초기 상태 AVAILABLE
     public static Reservation create(BuyerInfo buyer, SellerInfo seller, ProductInfo product) {
         Objects.requireNonNull(buyer, "buyer must not be null");
         Objects.requireNonNull(seller, "seller must not be null");
@@ -68,72 +63,85 @@ public class Reservation extends BaseEntity {
         reservation.buyerInfo = buyer;
         reservation.sellerInfo = seller;
         reservation.productInfo = product;
-        reservation.status = ReservationStatus.PENDING;
+        reservation.status = ReservationStatus.AVAILABLE;
         return reservation;
     }
 
-    // 결제 완료: PENDING 상태일 때만 가능
+    // 임시 예약: AVAILABLE 상태에서 결제 대기(점유) 단계로 진입
+    public void markAsPending() {
+        validateStatus(ReservationStatus.AVAILABLE);
+        this.status = ReservationStatus.PENDING;
+    }
+
+    // 결제 완료: PENDING(임시 예약) 상태일 때만 가능
     public void markAsPaid() {
         validateStatus(ReservationStatus.PENDING);
         this.status = ReservationStatus.PAID;
     }
 
-    // 예약 완료: PAID(결제 완료) 상태일 때만 가능
+    // 예약 완료: PAID(결제 완료) 상태에서 채팅 수락 시
     public void complete() {
         validateStatus(ReservationStatus.PAID);
         this.status = ReservationStatus.COMPLETED;
     }
 
-    // 예약 만료: PENDING 상태일 때만 가능
-    public void rollbackToPending() {
+    // 최종 종료: 완료된 거래를 아카이브 상태로 변경
+    public void close() {
         validateStatus(ReservationStatus.COMPLETED);
-        this.status = ReservationStatus.PENDING;
-        // 추후 기존 구매자의 후보자 상태를 'CANCELLED'로 바꾸는 로직 추가 예정
+        this.status = ReservationStatus.CLOSED;
     }
 
-    // 시간 만료: PENDING 상태일 때만 가능
-    public void expire() {
-        validateStatus(ReservationStatus.PENDING);
-        this.status = ReservationStatus.EXPIRED;
+    // 거래 복구: COMPLETED 상태에서 취소 발생 시 AVAILABLE로 복구
+    public void rollbackToAvailable() {
+        validateStatus(ReservationStatus.COMPLETED);
+        this.status = ReservationStatus.AVAILABLE;
     }
 
-    // 예약 취소: 취소 사유 업데이트 포함
-    public void cancel() {
-        validateStatus(ReservationStatus.PENDING);
-        this.status = ReservationStatus.CANCELLED;
+    // 구매자 취소: PENDING 또는 PAID 상태에서 구매자가 취소
+    public void cancelByBuyer() {
+        validateStatus(ReservationStatus.PENDING, ReservationStatus.PAID);
+        this.status = ReservationStatus.CANCELLED_BY_BUYER;
+    }
+
+    // 판매자 취소: PENDING 또는 PAID 상태에서 판매자가 취소(영구 종료)
+    public void cancelBySeller() {
+        validateStatus(ReservationStatus.PENDING, ReservationStatus.PAID);
+        this.status = ReservationStatus.CANCELLED_BY_SELLER;
     }
 
     // 다음 순번 구매자로 교체
     public void changeToNextBuyer(ReservationCandidate nextCandidate) {
-        // 예약 자체가 변경 가능한 상태인지 확인
-        validateStatus(ReservationStatus.PENDING);
+        // AVAILABLE 상태거나, 이전 구매자가 취소하여 기회가 생긴 경우에만 가능
+        validateStatus(ReservationStatus.AVAILABLE, ReservationStatus.CANCELLED_BY_BUYER);
 
-        // 인자 유효성 검사
         if (nextCandidate == null) {
             throw new IllegalArgumentException("nextBuyer must not be null");
         }
-        // 해당 후보자가 실제 이 예약의 후보 명단에 포함되어 있는지 검증
         if (!this.candidates.contains(nextCandidate)) {
             throw new ReservationException(ReservationErrorCode.INVALID_STATUS);
         }
-        // 후보자의 상태가 '대기' 중인지 확인
         if (nextCandidate.getStatus() != ReservationCandidateStatus.WAITING) {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }
+
         nextCandidate.selected();
-        // 검증 완료 후 구매자 정보 교체
+        // 새 구매자 정보로 교체 후 다시 임시 예약(PENDING) 상태로 변경
         this.buyerInfo = BuyerInfo.of(nextCandidate.getCandidateId(), nextCandidate.getCandidateNickname());
+        this.status = ReservationStatus.PENDING;
     }
 
-    private void validateStatus(ReservationStatus expectedStatus) {
-        // 결제가 취소이면 변경 불가
-        if (this.status == ReservationStatus.CANCELLED) {
+    // 상태 검증: 여러 허용 상태 중 하나라도 만족하는지 확인
+    private void validateStatus(ReservationStatus... expectedStatuses) {
+        // 판매자 취소나 최종 종료 상태인 경우 절대 변경 불가
+        if (this.status != null && !this.status.isMutable()) {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }
 
-        if (this.status != expectedStatus) {
+        boolean isValid = Arrays.stream(expectedStatuses)
+                .anyMatch(expected -> this.status == expected);
+
+        if (!isValid) {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }
     }
-
 }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/ReservationStatus.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/ReservationStatus.java
@@ -10,18 +10,28 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum ReservationStatus {
-    PENDING("임시 예약"),
-    PAID("결제 완료"),
-    EXPIRED("예약 만료"),
-    CANCELLED("예약 취소"),
-    COMPLETED("예약 완료");
+    AVAILABLE("예약 활성화", true),
+    PENDING("임시 예약(결제 전)", true),
+    PAID("결제 완료(채팅 전)", true),
+    COMPLETED("예약 완료(채팅 수락)", true),
+    CANCELLED_BY_BUYER("구매자 사유 취소", true),  // 변경 가능
+    CANCELLED_BY_SELLER("판매자 사유 취소", false), // 변경 불가
+    CLOSED("최종 종료", false);                   // 변경 불가
 
     private final String description;
+    private final boolean isMutable; // 상태 변경이 가능한 상태인지 여부
 
     public static ReservationStatus find(String statusName) {
         return Arrays.stream(values())
                 .filter(s -> s.name().equalsIgnoreCase(statusName))
                 .findFirst()
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.INVALID_STATUS));
+    }
+
+    /**
+     * 판매자 취소와 같은 종료 상태인지 확인
+     */
+    public boolean isFinalStatus() {
+        return !this.isMutable;
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -66,7 +66,7 @@ public class ReservationController {
         Page<ReservationResponse> responses = reservationService.getSearchReservations(userId, role, query, pageable)
                 .map(ReservationResponse::from);
 
-        // 3. 통일된 응답 규격으로 반환 (조회는 200 OK)
+        // 통일된 응답 규격으로 반환 (조회는 200 OK)
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(responses);


### PR DESCRIPTION
### 작업 배경
- 예약 상태 세분화에 따른 상태 추가

### 작업 내용
- 예약 상태 세분화
- 세분화에 따른 검증 로직 추가

### 테스트 여부
- 상태만 바꾸어 따로 테스트는 하지 않았습니다

### 기타
- https://www.notion.so/teamsparta/3452dc3ef51480ef9d94e4dfeb702416?source=copy_link

### 이슈
> This closes #11 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 검색 기능 추가 - 판매자명, 구매자명, 상품명, 상태, 상품ID로 필터링 가능
  * 예약 목록 페이지네이션 지원 추가

* **개선 사항**
  * 예약 상태 워크플로우 개선 (AVAILABLE, PENDING, PAID, COMPLETED, CANCELLED_BY_BUYER, CANCELLED_BY_SELLER, CLOSED)
  * Java 21로 업그레이드 및 Spring Cloud 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->