### PR TITLE
Feat/15 reservation cancel

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCancelCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCancelCommand.java
@@ -1,0 +1,14 @@
+package org.pgsg.reservation.application.dto.command;
+
+import java.util.UUID;
+
+public record ReservationCancelCommand(
+        UUID reservationId,
+        UUID userId,
+        String role,
+        String reason
+) {
+    public static ReservationCancelCommand of(UUID id, UUID userId, String role, String reason) {
+        return new ReservationCancelCommand(id, userId, role, reason);
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/info/ReservationCancelInfo.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/info/ReservationCancelInfo.java
@@ -1,0 +1,22 @@
+package org.pgsg.reservation.application.dto.info;
+
+import lombok.Builder;
+import org.pgsg.reservation.domain.model.reservation.Reservation;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ReservationCancelInfo(
+        UUID reservationId,
+        ReservationStatus status,
+        LocalDateTime updatedAt
+) {
+    public static ReservationCancelInfo from(Reservation reservation) {
+        return ReservationCancelInfo.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus())
+                .updatedAt(reservation.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -1,7 +1,9 @@
 package org.pgsg.reservation.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
+import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.dto.result.ReservationSearchResult;
@@ -142,24 +144,50 @@ public class ReservationService {
         return ReservationCandidateResponse.from(savedCandidate);
     }
 
-    // 예약 취소
+    // 구매자 취소 처리 로직
     @Transactional
-    public void cancelReservation(UUID reservationId, UUID userId, String reason) {
-        // DB에서 예약 애그리거트 조회
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+    public ReservationCancelInfo cancelByBuyer(ReservationCancelCommand command) {
+        Reservation reservation = findById(command.reservationId());
 
-        // 도메인 서비스에 취소 로직 위임
-        ReservationHistory history = reservationDomainService.cancel(reservation, userId, reason);
+        ReservationHistory history = reservationDomainService.cancelByBuyer(
+                reservation,
+                command.userId(),
+                command.role(),
+                command.reason()
+        );
 
-        // 변경 사항 저장 (Persistence)
-        // 새로 생성된 이력(History)은 명시적으로 저장
         reservationHistoryRepository.save(history);
+
+        return ReservationCancelInfo.from(reservation);
+    }
+
+    // 판매자 취소 로직
+    @Transactional
+    public ReservationCancelInfo cancelBySeller(ReservationCancelCommand command) {
+        Reservation reservation = findById(command.reservationId());
+
+        ReservationHistory history = reservationDomainService.cancelBySeller(
+                reservation,
+                command.userId(),
+                command.role(),
+                command.reason()
+        );
+
+        reservationHistoryRepository.save(history);
+
+        return ReservationCancelInfo.from(reservation);
+    }
+
+    /**
+     * 공통 ID 조회 메서드
+     */
+    private Reservation findById(UUID reservationId) {
+        return reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     }
 
     private boolean isDuplicateApplyViolation(DataIntegrityViolationException e) {
         String message = e.getMostSpecificCause().getMessage();
         return message != null && message.contains("uk_reservation_candidate_user_id");
     }
-
 }

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -10,6 +10,8 @@ import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.exception.ReservationException;
 import org.pgsg.reservation.domain.model.reservation.*;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
+import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
+import org.pgsg.reservation.domain.repository.ReservationHistoryRepository;
 import org.pgsg.reservation.domain.service.ReservationDomainService;
 import org.pgsg.reservation.domain.repository.ReservationRepository;
 import org.pgsg.reservation.presentation.dto.response.ReservationCandidateResponse;
@@ -28,6 +30,7 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
     private final ReservationDomainService reservationDomainService;
+    private final ReservationHistoryRepository reservationHistoryRepository;
     // private final ProductClient productClient; // 추후 구현 예정
 
     // 도메인 서비스 호출 전까지의 작업은 트랜잭션 밖으로 분리(추후 고도화 작업시)
@@ -139,8 +142,24 @@ public class ReservationService {
         return ReservationCandidateResponse.from(savedCandidate);
     }
 
+    // 예약 취소
+    @Transactional
+    public void cancelReservation(UUID reservationId, UUID userId, String reason) {
+        // DB에서 예약 애그리거트 조회
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        // 도메인 서비스에 취소 로직 위임
+        ReservationHistory history = reservationDomainService.cancel(reservation, userId, reason);
+
+        // 변경 사항 저장 (Persistence)
+        // 새로 생성된 이력(History)은 명시적으로 저장
+        reservationHistoryRepository.save(history);
+    }
+
     private boolean isDuplicateApplyViolation(DataIntegrityViolationException e) {
         String message = e.getMostSpecificCause().getMessage();
         return message != null && message.contains("uk_reservation_candidate_user_id");
     }
+
 }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
@@ -103,6 +103,15 @@ public class Reservation extends BaseEntity {
         this.status = ReservationStatus.CANCELLED_BY_BUYER;
     }
 
+    // 대기자가 없을 경우, 다시 누구나 신청 가능한 상태로 복구
+    public void reopen() {
+        // 현재 상태가 취소된 상태여야 재오픈 가능 (보안 및 로직 검증)
+        validateStatus(ReservationStatus.CANCELLED_BY_BUYER);
+
+        this.status = ReservationStatus.AVAILABLE;
+        this.buyerInfo = null; // 기존 구매자 정보 제거
+    }
+
     // 판매자 취소: PENDING 또는 PAID 상태에서 판매자가 취소(영구 종료)
     public void cancelBySeller() {
         validateStatus(ReservationStatus.PENDING, ReservationStatus.PAID);

--- a/src/main/java/org/pgsg/reservation/domain/model/reservationcandidate/ReservationCandidate.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservationcandidate/ReservationCandidate.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Table(name = "p_reservation_candidates", uniqueConstraints = {
         @UniqueConstraint(
                 name = "uk_reservation_candidate_user_id",
-                columnNames = {"reservation_id", "candidateId"}
+                columnNames = {"reservation_id", "candidate_id"}
         )
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,10 +30,14 @@ public class ReservationCandidate extends BaseEntity {
     @JoinColumn(name = "reservation_id")
     private Reservation reservation;
 
+    @Column(name = "candidate_id", nullable = false)
     private UUID candidateId;      // 후보자 식별자
+
+    @Column(nullable = false)
     private String candidateNickname; // 후보자 닉네임
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ReservationCandidateStatus status = ReservationCandidateStatus.WAITING;
 
     // 예약 후보 생성

--- a/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
@@ -1,0 +1,44 @@
+package org.pgsg.reservation.domain.model.reservationhistory;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_reservation_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReservationHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID reservationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus newStatus;
+
+    private String comment; // 변경 사유
+
+    @Column(nullable = false)
+    private UUID changedBy; // 상태를 변경한 사용자 ID
+
+    // 상태 변경 이력을 생성
+    public static ReservationHistory of(UUID reservationId, ReservationStatus previousStatus,
+                                        ReservationStatus newStatus, String comment, UUID changedBy) {
+        return new ReservationHistory(null, reservationId, previousStatus, newStatus, comment, changedBy);
+    }
+}

--- a/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
@@ -44,5 +44,4 @@ public class ReservationHistory {
         }
         return new ReservationHistory(null, reservationId, previousStatus, newStatus, comment, changedBy);
     }
-    }
 }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
@@ -39,6 +39,10 @@ public class ReservationHistory {
     // 상태 변경 이력을 생성
     public static ReservationHistory of(UUID reservationId, ReservationStatus previousStatus,
                                         ReservationStatus newStatus, String comment, UUID changedBy) {
+        if (comment == null || comment.isBlank()) {
+            throw new IllegalArgumentException("comment must not be blank");
+        }
         return new ReservationHistory(null, reservationId, previousStatus, newStatus, comment, changedBy);
+    }
     }
 }

--- a/src/main/java/org/pgsg/reservation/domain/repository/ReservationHistoryRepository.java
+++ b/src/main/java/org/pgsg/reservation/domain/repository/ReservationHistoryRepository.java
@@ -1,0 +1,7 @@
+package org.pgsg.reservation.domain.repository;
+
+import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
+
+public interface ReservationHistoryRepository {
+    ReservationHistory save(ReservationHistory history);
+}

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -5,8 +5,11 @@ import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.exception.ReservationException;
 import org.pgsg.reservation.domain.model.reservation.*;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
+import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidateStatus;
+import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -102,5 +105,52 @@ public class ReservationDomainService {
         }
 
         return candidate;
+    }
+
+    /**
+     * 판매자,구매자 예약 취소
+     * 해당 취소 사유자가 권한이 있는지 확인하기
+     */
+    public ReservationHistory cancel(Reservation reservation, UUID userId, String reason) {
+        // 검증 로직
+        reservationValidator.validateCancel(reservation, userId);
+
+        ReservationStatus previousStatus = reservation.getStatus();
+
+        // 취소 주체 판별 및 상태 변경
+        if (isBuyer(reservation, userId)) {
+            reservation.cancelByBuyer();
+            // 구매자 취소 시 다음 순번 승계 시도
+            handleNextBuyerSequence(reservation);
+        } else {
+            // 판매자 취소
+            reservation.cancelBySeller();
+        }
+
+        // 이력 객체 생성 및 반환
+        return ReservationHistory.of(
+                reservation.getId(),
+                previousStatus,
+                reservation.getStatus(),
+                reason,
+                userId
+        );
+    }
+
+    /**
+     * 다음 구매자 승계 내부 로직
+     */
+    private void handleNextBuyerSequence(Reservation reservation) {
+        // 기획서 규칙: WAITING 상태 중 생성일 오름차순 -> ID 오름차순
+        reservation.getCandidates().stream()
+                .filter(c -> c.getStatus() == ReservationCandidateStatus.WAITING)
+                .min(Comparator.comparing(ReservationCandidate::getCreatedAt)
+                        .thenComparing(ReservationCandidate::getId))
+                .ifPresent(reservation::changeToNextBuyer);
+    }
+
+    private boolean isBuyer(Reservation reservation, UUID userId) {
+        return reservation.getBuyerInfo() != null &&
+                reservation.getBuyerInfo().getBuyerId().equals(userId);
     }
 }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -110,31 +110,49 @@ public class ReservationDomainService {
     }
 
     /**
-     * 판매자,구매자 예약 취소
-     * 해당 취소 사유자가 권한이 있는지 확인하기
+     * 구매자 사유 취소 도메인 로직
+     * 구매자 혹은 관리자가 호출하며, 취소 후 다음 대기자에게 예약 권한을 승계함
      */
-    public ReservationHistory cancel(Reservation reservation, UUID userId, String reason) {
-        // 취소 사유 검증
-        if (reason == null || reason.isBlank()) {
-            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
-        }
+    public ReservationHistory cancelByBuyer(Reservation reservation, UUID userId, String role, String reason) {
+        validateReason(reason);
 
-        // 검증 로직
-        reservationValidator.validateCancel(reservation, userId);
+        // 권한 및 상태 검증
+        reservationValidator.validateCancelByBuyer(reservation, userId, role);
 
         ReservationStatus previousStatus = reservation.getStatus();
 
-        // 취소 주체 판별 및 상태 변경
-        if (isBuyer(reservation, userId)) {
-            reservation.cancelByBuyer();
-            // 구매자 취소 시 다음 순번 승계 시도
-            handleNextBuyerSequence(reservation);
-        } else {
-            // 판매자 취소
-            reservation.cancelBySeller();
-        }
+        // 엔티티 상태 변경
+        reservation.cancelByBuyer();
 
-        // 이력 객체 생성 및 반환
+        // 다음 구매자 승계 처리
+        handleNextBuyerSequence(reservation);
+
+        // 이력 객체 생성
+        return ReservationHistory.of(
+                reservation.getId(),
+                previousStatus,
+                reservation.getStatus(),
+                reason,
+                userId
+        );
+    }
+
+    /**
+     * 판매자 사유 취소 도메인 로직
+     * 판매자 혹은 관리자가 호출하며, 취소 후 예약 비활성화 후 상품 삭제 요청
+     */
+    public ReservationHistory cancelBySeller(Reservation reservation, UUID userId, String role, String reason) {
+        validateReason(reason);
+
+        // 권한 및 상태 검증
+        reservationValidator.validateCancelBySeller(reservation, userId, role);
+
+        ReservationStatus previousStatus = reservation.getStatus();
+
+        // 엔티티 상태 변경
+        reservation.cancelBySeller();
+
+        // 이력 객체 생성
         return ReservationHistory.of(
                 reservation.getId(),
                 previousStatus,
@@ -164,8 +182,9 @@ public class ReservationDomainService {
         }
     }
 
-    private boolean isBuyer(Reservation reservation, UUID userId) {
-        return reservation.getBuyerInfo() != null &&
-                reservation.getBuyerInfo().getBuyerId().equals(userId);
+    private void validateReason(String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
+        }
     }
 }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -114,6 +114,11 @@ public class ReservationDomainService {
      * 해당 취소 사유자가 권한이 있는지 확인하기
      */
     public ReservationHistory cancel(Reservation reservation, UUID userId, String reason) {
+        // 취소 사유 검증
+        if (reason == null || reason.isBlank()) {
+            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
+        }
+
         // 검증 로직
         reservationValidator.validateCancel(reservation, userId);
 

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 
 
@@ -92,15 +93,16 @@ public class ReservationDomainService {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }
 
+        // 현재 구매자가 없는 상태(reopen된 상태)라면 내가 바로 구매자가 변경
+        boolean shouldBeSelectedImmediately = (reservation.getBuyerInfo() == null);
+
         // 후보자 생성 및 애그리거트에 추가
         ReservationCandidate candidate = ReservationCandidate.create(reservation, userId, nickname);
-        // 현재 후보자가 없을 경우 첫 번째 신청자로 생각
-        boolean isFirstCandidate = reservation.getCandidates().isEmpty();
 
         reservation.addCandidate(candidate);
 
         // 만약 첫 번째 후보자라면 바로 구매자로 선정하는 로직
-        if (isFirstCandidate) {
+        if (shouldBeSelectedImmediately) {
             reservation.changeToNextBuyer(candidate);
         }
 
@@ -141,12 +143,20 @@ public class ReservationDomainService {
      * 다음 구매자 승계 내부 로직
      */
     private void handleNextBuyerSequence(Reservation reservation) {
-        // 기획서 규칙: WAITING 상태 중 생성일 오름차순 -> ID 오름차순
-        reservation.getCandidates().stream()
+        // WAITING 상태 중 생성일 오름차순 -> ID 오름차순
+        // 대기자 중 가장 우선 우선순위가 높은 사람을 찾음
+        Optional<ReservationCandidate> nextCandidate = reservation.getCandidates().stream()
                 .filter(c -> c.getStatus() == ReservationCandidateStatus.WAITING)
                 .min(Comparator.comparing(ReservationCandidate::getCreatedAt)
-                        .thenComparing(ReservationCandidate::getId))
-                .ifPresent(reservation::changeToNextBuyer);
+                        .thenComparing(ReservationCandidate::getId));
+
+        if (nextCandidate.isPresent()) {
+            // a. 대기자가 있으면 승계 처리
+            reservation.changeToNextBuyer(nextCandidate.get());
+        } else {
+            // b. 대기자가 없으면 다시 누구나 신청 가능한 상태로 복구
+            reservation.reopen();
+        }
     }
 
     private boolean isBuyer(Reservation reservation, UUID userId) {

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
@@ -4,6 +4,7 @@ import org.pgsg.reservation.domain.model.reservation.*;
 import org.pgsg.reservation.domain.exception.*;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -37,17 +38,24 @@ public class ReservationValidator {
 
     // 취소 권한 및 상태 검증
     public void validateCancel(Reservation reservation, UUID userId) {
-        // 권한 확인 (구매자 혹은 판매자인지)
+        // 예약 객체 자체나 유저 ID가 없는 경우
+        if (reservation == null || userId == null) {
+            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
+        }
+
+        // 권한 확인 (판매자 or 구매자 인지)
         boolean isBuyer = reservation.getBuyerInfo() != null &&
-                reservation.getBuyerInfo().getBuyerId().equals(userId);
-        boolean isSeller = reservation.getSellerInfo().getSellerId().equals(userId);
+                Objects.equals(reservation.getBuyerInfo().getBuyerId(), userId);
+
+        boolean isSeller = reservation.getSellerInfo() != null &&
+                Objects.equals(reservation.getSellerInfo().getSellerId(), userId);
 
         if (!isBuyer && !isSeller) {
             throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // 상태 확인 (취소 가능한 상태인지)
-        if (!reservation.getStatus().isMutable()) {
+        if (reservation.getStatus() == null || !reservation.getStatus().isMutable()) {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }
     }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
@@ -36,25 +36,41 @@ public class ReservationValidator {
         }
     }
 
-    // 취소 권한 및 상태 검증
-    public void validateCancel(Reservation reservation, UUID userId) {
-        // 예약 객체 자체나 유저 ID가 없는 경우
-        if (reservation == null || userId == null) {
-            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
-        }
+    // 구매자,관리자 취소 권한 및 상태 검증
+    public void validateCancelByBuyer(Reservation reservation, UUID userId, String role) {
+        validateCommonCancel(reservation, userId);
 
-        // 권한 확인 (판매자 or 구매자 인지)
         boolean isBuyer = reservation.getBuyerInfo() != null &&
                 Objects.equals(reservation.getBuyerInfo().getBuyerId(), userId);
+
+        boolean isAdmin = "ADMIN".equalsIgnoreCase(role);
+
+        if (!isBuyer && !isAdmin) {
+            throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    // 판매자,관리자 취소 권한 및 상태 검증
+    public void validateCancelBySeller(Reservation reservation, UUID userId, String role) {
+        validateCommonCancel(reservation, userId);
 
         boolean isSeller = reservation.getSellerInfo() != null &&
                 Objects.equals(reservation.getSellerInfo().getSellerId(), userId);
 
-        if (!isBuyer && !isSeller) {
+        boolean isAdmin = "ADMIN".equalsIgnoreCase(role);
+
+        if (!isSeller && !isAdmin) {
             throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
         }
+    }
 
-        // 상태 확인 (취소 가능한 상태인지)
+    // 공통 취소 가능 상태 검증
+    private void validateCommonCancel(Reservation reservation, UUID userId) {
+        if (reservation == null || userId == null) {
+            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
+        }
+
+        // 이미 종료된 상태이거나 취소 불가능한 상태인지 확인
         if (reservation.getStatus() == null || !reservation.getStatus().isMutable()) {
             throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
         }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
@@ -35,6 +35,23 @@ public class ReservationValidator {
         }
     }
 
+    // 취소 권한 및 상태 검증
+    public void validateCancel(Reservation reservation, UUID userId) {
+        // 권한 확인 (구매자 혹은 판매자인지)
+        boolean isBuyer = reservation.getBuyerInfo() != null &&
+                reservation.getBuyerInfo().getBuyerId().equals(userId);
+        boolean isSeller = reservation.getSellerInfo().getSellerId().equals(userId);
+
+        if (!isBuyer && !isSeller) {
+            throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 상태 확인 (취소 가능한 상태인지)
+        if (!reservation.getStatus().isMutable()) {
+            throw new ReservationException(ReservationErrorCode.CANNOT_CHANGE_STATUS);
+        }
+    }
+
     // 본인 상품 예약 금지 규칙
     private boolean isSamePerson(BuyerInfo buyer, SellerInfo seller) {
         return buyer.getBuyerId().equals(seller.getSellerId());

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/ReservationHistoryRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/ReservationHistoryRepositoryImpl.java
@@ -1,0 +1,19 @@
+package org.pgsg.reservation.infrastructure.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
+import org.pgsg.reservation.domain.repository.ReservationHistoryRepository;
+import org.pgsg.reservation.infrastructure.repository.reservationhistory.JpaReservationHistoryRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReservationHistoryRepositoryImpl implements ReservationHistoryRepository {
+
+    private final JpaReservationHistoryRepository jpaRepository;
+
+    @Override
+    public ReservationHistory save(ReservationHistory history) {
+        return jpaRepository.save(history);
+    }
+}

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
@@ -1,4 +1,4 @@
-package org.pgsg.reservation.infrastructure.repository;
+package org.pgsg.reservation.infrastructure.repository.reservation;
 
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -1,4 +1,4 @@
-package org.pgsg.reservation.infrastructure.repository;
+package org.pgsg.reservation.infrastructure.repository.reservation;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservationhistory/JpaReservationHistoryRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservationhistory/JpaReservationHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.pgsg.reservation.infrastructure.repository.reservationhistory;
+
+import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface JpaReservationHistoryRepository extends JpaRepository<ReservationHistory, UUID> {
+}

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -2,10 +2,12 @@ package org.pgsg.reservation.presentation.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.pgsg.config.security.UserDetailsImpl;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.service.ReservationService;
+import org.pgsg.reservation.presentation.dto.request.ReservationCancelRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationCreateRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationSearchRequest;
 import org.pgsg.reservation.presentation.dto.response.ReservationCandidateResponse;
@@ -16,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -68,7 +71,7 @@ public class ReservationController {
         Page<ReservationResponse> responses = reservationService.getSearchReservations(userId, role, query, pageable)
                 .map(ReservationResponse::from);
 
-        // 3. 통일된 응답 규격으로 반환 (조회는 200 OK)
+        // 통일된 응답 규격으로 반환 (조회는 200 OK)
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(responses);
@@ -87,7 +90,7 @@ public class ReservationController {
         return ResponseEntity.ok(response);
     }
 
-    //예약 신청
+    // 예약 신청
     @PostMapping("/{reservationId}")
     public ResponseEntity<ReservationCandidateResponse> applyReservation(
             @PathVariable UUID reservationId,
@@ -97,5 +100,22 @@ public class ReservationController {
         ReservationCandidateResponse response = reservationService.applyReservation(reservationId, userId, nickname);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 예약 취소
+    @PatchMapping("/{reservationId}/cancel")
+    public ResponseEntity<Void> cancelReservation(
+            @PathVariable UUID reservationId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody ReservationCancelRequest request
+    ) {
+
+        reservationService.cancelReservation(
+                reservationId,
+                userDetails.getUuid(), // 취소 수행자 ID
+                request.reason() // 취소 사유
+        );
+
+        return ResponseEntity.noContent().build(); // 204 No Content 응답
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -3,13 +3,16 @@ package org.pgsg.reservation.presentation.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.pgsg.config.security.UserDetailsImpl;
+import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
+import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.service.ReservationService;
 import org.pgsg.reservation.presentation.dto.request.ReservationCancelRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationCreateRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationSearchRequest;
+import org.pgsg.reservation.presentation.dto.response.ReservationCancelResponse;
 import org.pgsg.reservation.presentation.dto.response.ReservationCandidateResponse;
 import org.pgsg.reservation.presentation.dto.response.ReservationDetailResponse;
 import org.pgsg.reservation.presentation.dto.response.ReservationResponse;
@@ -102,20 +105,43 @@ public class ReservationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // 예약 취소
-    @PatchMapping("/{reservationId}/cancel")
-    public ResponseEntity<Void> cancelReservation(
+    // 구매자 사유 취소 (구매자/관리자)
+    @PatchMapping("/{reservationId}/cancel/buyer")
+    public ResponseEntity<ReservationCancelResponse> cancelByBuyer(
             @PathVariable UUID reservationId,
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody ReservationCancelRequest request
+            @RequestBody ReservationCancelRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails // AuthUser를 UserDetailsImpl로 통일
     ) {
-
-        reservationService.cancelReservation(
+        ReservationCancelCommand command = ReservationCancelCommand.of(
                 reservationId,
-                userDetails.getUuid(), // 취소 수행자 ID
-                request.reason() // 취소 사유
+                userDetails.getUuid(),
+                userDetails.getUserRole(),
+                request.reason()
         );
 
-        return ResponseEntity.noContent().build(); // 204 No Content 응답
+        ReservationCancelInfo info = reservationService.cancelByBuyer(command);
+        ReservationCancelResponse response = ReservationCancelResponse.of(info, "구매자 사유 취소가 완료되었습니다.");
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 판매자 사유로 인한 취소(판매자,관리자)
+    @PatchMapping("/{reservationId}/cancel/seller")
+    public ResponseEntity<ReservationCancelResponse> cancelBySeller(
+            @PathVariable UUID reservationId,
+            @RequestBody ReservationCancelRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReservationCancelCommand command = ReservationCancelCommand.of(
+                reservationId,
+                userDetails.getUuid(),
+                userDetails.getUserRole(),
+                request.reason()
+        );
+
+        ReservationCancelInfo info = reservationService.cancelBySeller(command);
+        ReservationCancelResponse response = ReservationCancelResponse.of(info, "판매자 사유 취소가 완료되었습니다.");
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationCancelRequest.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationCancelRequest.java
@@ -1,0 +1,8 @@
+package org.pgsg.reservation.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReservationCancelRequest(
+        @NotBlank(message = "취소 사유를 입력해주세요.")
+        String reason
+) {}

--- a/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCancelResponse.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCancelResponse.java
@@ -1,0 +1,24 @@
+package org.pgsg.reservation.presentation.dto.response;
+
+import lombok.Builder;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ReservationCancelResponse(
+        UUID reservationId,
+        ReservationStatus status,
+        LocalDateTime updatedAt,
+        String message
+) {
+    public static ReservationCancelResponse of(Object reservation, String message) {
+        return ReservationCancelResponse.builder()
+                .reservationId(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getId())
+                .status(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getStatus())
+                .updatedAt(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getModifiedAt())
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCancelResponse.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCancelResponse.java
@@ -1,6 +1,7 @@
 package org.pgsg.reservation.presentation.dto.response;
 
 import lombok.Builder;
+import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
 import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 
 import java.time.LocalDateTime;
@@ -13,11 +14,11 @@ public record ReservationCancelResponse(
         LocalDateTime updatedAt,
         String message
 ) {
-    public static ReservationCancelResponse of(Object reservation, String message) {
+    public static ReservationCancelResponse of(ReservationCancelInfo info, String message) {
         return ReservationCancelResponse.builder()
-                .reservationId(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getId())
-                .status(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getStatus())
-                .updatedAt(((org.pgsg.reservation.domain.model.reservation.Reservation) reservation).getModifiedAt())
+                .reservationId(info.reservationId())
+                .status(info.status())
+                .updatedAt(info.updatedAt())
                 .message(message)
                 .build();
     }


### PR DESCRIPTION
### 작업 배경
- 예약 취소 기능

### 작업 내용
- 예약 관리 엔티티 작성
- 예약 취소 관리 기능 구현
- repository의 클래스들이 많아 폴더로 세분화 작업

### 테스트 여부
- .\gradlew clean build -x test 통과

### 기타
- 관리자 처리를 어떻게 하냐에 따라 api 추가나 api 수정이 추후에 있을 수 있음

### 이슈
> This closes #15 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 구매자/판매자별 예약 취소 API 추가(PATCH), 취소 사유 제출로 취소 처리 및 상세 응답 반환(200 OK).
  * 취소 이력 저장: 이전/새 상태, 사유, 변경자 정보 영구 기록.
  * 구매자 취소 시 대기자 자동 승계 또는 재오픈 처리 기능 추가.
  * 취소 입력 검증 및 권한 검사 강화(역할·신원 기반).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->