### PR TITLE
Feat/17 reservation expire

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -16,6 +16,7 @@ import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.pgsg.reservation.domain.repository.ReservationHistoryRepository;
 import org.pgsg.reservation.domain.service.ReservationDomainService;
 import org.pgsg.reservation.domain.repository.ReservationRepository;
+import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
 import org.pgsg.reservation.presentation.dto.response.ReservationCandidateResponse;
 import org.pgsg.reservation.presentation.dto.response.ReservationDetailResponse;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -178,6 +179,29 @@ public class ReservationService {
         return ReservationCancelInfo.from(reservation);
     }
 
+    // 예약 만료
+    @Transactional
+    public ReservationCancelInfo expireByAdmin(
+            UUID reservationId,
+            ReservationAdminCancelRequest request,
+            UUID adminId,
+            String role
+    ) {
+        Reservation reservation = findById(reservationId);
+
+        ReservationHistory history = reservationDomainService.expireByAdmin(
+                reservation,
+                adminId,
+                role,
+                request.targetStatus(),
+                request.reason()
+        );
+
+        reservationHistoryRepository.save(history);
+
+        return ReservationCancelInfo.from(reservation);
+    }
+
     /**
      * 공통 ID 조회 메서드
      */
@@ -190,4 +214,5 @@ public class ReservationService {
         String message = e.getMostSpecificCause().getMessage();
         return message != null && message.contains("uk_reservation_candidate_user_id");
     }
+
 }

--- a/src/main/java/org/pgsg/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/org/pgsg/reservation/domain/repository/ReservationRepository.java
@@ -2,9 +2,12 @@ package org.pgsg.reservation.domain.repository;
 
 import org.pgsg.reservation.domain.dto.ReservationSearchCriteria;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,4 +21,7 @@ public interface ReservationRepository {
     Page<Reservation> findByCriteria(ReservationSearchCriteria criteria, Pageable pageable);
 
     Optional<Reservation> findById(UUID id);
+
+    // 예약 만료 스케줄링용
+    List<Reservation> findAllByStatusInAndModifiedAtBefore(List<ReservationStatus> statuses, LocalDateTime threshold);
 }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -173,8 +173,13 @@ public class ReservationDomainService {
             ReservationStatus targetStatus,
             String reason
     ) {
+        validateReason(reason);
+
         // 관리자 권한 및 취소 가능 상태인지 확인
         reservationValidator.validateSearchRequest(adminId, role);
+        if (!"ADMIN".equalsIgnoreCase(role == null ? null : role.trim())) {
+            throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
+        }
         reservationValidator.validateCommonCancel(reservation, adminId);
 
         // 이력 기록을 위해 변경 전 상태 보관

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -163,6 +163,50 @@ public class ReservationDomainService {
     }
 
     /**
+     * 예약 만료 로직
+     * 예약이 만료 될 시 작동 혹은 시스템 문제로 관리자 임의 실행
+     */
+    public ReservationHistory expireByAdmin(
+            Reservation reservation,
+            UUID adminId,
+            String role,
+            ReservationStatus targetStatus,
+            String reason
+    ) {
+        // 관리자 권한 및 취소 가능 상태인지 확인
+        reservationValidator.validateSearchRequest(adminId, role);
+        reservationValidator.validateCommonCancel(reservation, adminId);
+
+        // 이력 기록을 위해 변경 전 상태 보관
+        ReservationStatus previousStatus = reservation.getStatus();
+
+        // 상태 변경
+        if (targetStatus == ReservationStatus.CANCELLED_BY_BUYER) {
+            // 구매자 사유 취소로 취급 -> 차순위 승계(handleNextBuyer) 로직 작동
+            reservation.cancelByBuyer();
+
+            // 여기서 직접 차순위 로직을 호출하거나, 이벤트를 발행
+            handleNextBuyerSequence(reservation);
+
+        } else if (targetStatus == ReservationStatus.CANCELLED_BY_SELLER) {
+            // 판매자 사유 취소로 취급 -> 승계 없이 최종 종료
+            reservation.cancelBySeller();
+        } else {
+            // 그 외 정의되지 않은 상태 변경 시도 시 예외
+            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
+        }
+
+        // 3. 결과물(History) 생성 및 반환
+        return ReservationHistory.of(
+                reservation.getId(),
+                previousStatus,
+                reservation.getStatus(),
+                reason,
+                adminId
+        );
+    }
+
+    /**
      * 다음 구매자 승계 내부 로직
      */
     private void handleNextBuyerSequence(Reservation reservation) {

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
@@ -65,7 +65,7 @@ public class ReservationValidator {
     }
 
     // 공통 취소 가능 상태 검증
-    private void validateCommonCancel(Reservation reservation, UUID userId) {
+    public void validateCommonCancel(Reservation reservation, UUID userId) {
         if (reservation == null || userId == null) {
             throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
         }

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
@@ -1,0 +1,13 @@
+package org.pgsg.reservation.infrastructure.repository.reservation;
+
+import org.pgsg.reservation.domain.model.reservation.Reservation;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaReservationRepository extends JpaRepository<Reservation, UUID> {
+    List<Reservation> findAllByStatusAndExpirationTimeBefore(ReservationStatus status, LocalDateTime now);
+}

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
@@ -9,5 +9,4 @@ import java.util.List;
 import java.util.UUID;
 
 public interface JpaReservationRepository extends JpaRepository<Reservation, UUID> {
-    List<Reservation> findAllByStatusAndExpirationTimeBefore(ReservationStatus status, LocalDateTime now);
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
@@ -1,8 +1,0 @@
-package org.pgsg.reservation.infrastructure.repository.reservation;
-
-import org.pgsg.reservation.domain.model.reservation.Reservation;
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
-
-public interface ReservationJpaRepository extends JpaRepository<Reservation, UUID> {
-}

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -46,6 +46,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
             List<ReservationStatus> statuses,
             LocalDateTime threshold
     ){
+        if (statuses == null || statuses.isEmpty() || threshold == null) {
+            return List.of();
+        }
         return queryFactory
                 .selectFrom(reservation)
                 .where(

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,7 +23,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ReservationRepositoryImpl implements ReservationRepository {
 
-    private final ReservationJpaRepository reservationJpaRepository;
+    private final JpaReservationRepository reservationJpaRepository;
     private final JPAQueryFactory queryFactory;
 
     private final PathBuilder<Reservation> reservation =
@@ -36,6 +37,20 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public Reservation saveAndFlush(Reservation reservationEntity) {
         return reservationJpaRepository.saveAndFlush(reservationEntity);
+    }
+
+    @Override
+    public List<Reservation> findAllByStatusInAndModifiedAtBefore(
+            List<ReservationStatus> statuses,
+            LocalDateTime threshold
+    ){
+        return queryFactory
+                .selectFrom(reservation)
+                .where(
+                        statusIn(statuses),
+                        modifiedAtBefore(threshold)
+                )
+                .fetch();
     }
 
     @Override
@@ -114,6 +129,18 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         String normalized = buyerName == null ? null : buyerName.trim();
         return (normalized != null && !normalized.isBlank())
                 ? reservation.get("buyerInfo").getString("buyerName").containsIgnoreCase(normalized)
+                : null;
+    }
+
+    private BooleanExpression statusIn(List<ReservationStatus> statuses) {
+        return statuses != null && !statuses.isEmpty()
+                ? reservation.get("status", ReservationStatus.class).in(statuses)
+                : null;
+    }
+
+    private BooleanExpression modifiedAtBefore(LocalDateTime threshold) {
+        return threshold != null
+                ? reservation.getDateTime("modifiedAt", LocalDateTime.class).before(threshold)
                 : null;
     }
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,6 +41,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Reservation> findAllByStatusInAndModifiedAtBefore(
             List<ReservationStatus> statuses,
             LocalDateTime threshold

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservationhistory/ReservationHistoryRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservationhistory/ReservationHistoryRepositoryImpl.java
@@ -1,9 +1,8 @@
-package org.pgsg.reservation.infrastructure.repository;
+package org.pgsg.reservation.infrastructure.repository.reservationhistory;
 
 import lombok.RequiredArgsConstructor;
 import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.pgsg.reservation.domain.repository.ReservationHistoryRepository;
-import org.pgsg.reservation.infrastructure.repository.reservationhistory.JpaReservationHistoryRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
@@ -9,7 +9,6 @@ import org.pgsg.reservation.domain.repository.ReservationRepository;
 import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,7 +30,6 @@ public class ReservationExpiryScheduler {
      * 매 1분마다 만료된 예약을 체크하여 자동 취소 처리
      */
     @Scheduled(cron = "0 * * * * *")
-    @Transactional
     public void autoExpireReservations() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(60);
         List<ReservationStatus> targetStatuses = List.of(ReservationStatus.PENDING, ReservationStatus.PAID);

--- a/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
@@ -1,0 +1,84 @@
+package org.pgsg.reservation.infrastructure.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.reservation.application.service.ReservationService;
+import org.pgsg.reservation.domain.model.reservation.Reservation;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+import org.pgsg.reservation.domain.repository.ReservationRepository;
+import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationExpiryScheduler {
+
+    private final ReservationService reservationService;
+    private final ReservationRepository reservationRepository;
+
+    // 시스템 자동 처리를 위한 가상의 관리자 ID (추후 시스템 관리자 용 id 따로 추가)
+    private static final UUID SYSTEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static final String SYSTEM_ROLE = "ADMIN";
+
+    /**
+     * 매 1분마다 만료된 예약을 체크하여 자동 취소 처리
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void autoExpireReservations() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(60);
+        List<ReservationStatus> targetStatuses = List.of(ReservationStatus.PENDING, ReservationStatus.PAID);
+
+        List<Reservation> expiredReservations = reservationRepository.findAllByStatusInAndModifiedAtBefore(
+                targetStatuses,
+                threshold
+        );
+
+        if (expiredReservations.isEmpty()) return;
+
+        log.info("시스템 자동 만료 처리 시작: {}건", expiredReservations.size());
+
+        for (Reservation reservation : expiredReservations) {
+            try {
+                // 현재 예약 상태에 맞는 요청 객체를 생성
+                ReservationAdminCancelRequest request = createCancelRequest(reservation);
+
+                reservationService.expireByAdmin(
+                        reservation.getId(),
+                        request,
+                        SYSTEM_ID,
+                        SYSTEM_ROLE
+                );
+            } catch (Exception e) {
+                log.error("예약 자동 만료 처리 중 오류 발생 (ID: {}): {}", reservation.getId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 예약 상태에 따른 적절한 취소 요청 객체를 생성하는 메서드
+     */
+    private ReservationAdminCancelRequest createCancelRequest(Reservation reservation) {
+
+        //
+        if (reservation.getStatus() == ReservationStatus.PENDING) {
+            return new ReservationAdminCancelRequest(
+                    ReservationStatus.CANCELLED_BY_BUYER,
+                    "결제 제한 시간(1시간) 초과로 인한 자동 취소"
+            );
+        }
+
+        // PAID 상태일 때
+        return new ReservationAdminCancelRequest(
+                ReservationStatus.CANCELLED_BY_SELLER,
+                "채팅 수락 제한 시간(1시간) 초과로 인한 자동 취소"
+        );
+    }
+}

--- a/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
@@ -74,9 +74,12 @@ public class ReservationExpiryScheduler {
         }
 
         // PAID 상태일 때
-        return new ReservationAdminCancelRequest(
-                ReservationStatus.CANCELLED_BY_SELLER,
-                "채팅 수락 제한 시간(1시간) 초과로 인한 자동 취소"
-        );
+        if (reservation.getStatus() == ReservationStatus.PAID) {
+            return new ReservationAdminCancelRequest(
+                    ReservationStatus.CANCELLED_BY_SELLER,
+                    "채팅 수락 제한 시간(1시간) 초과로 인한 자동 취소"
+            );
+        }
+        throw new IllegalStateException("자동 만료 대상이 아닌 상태입니다: " + reservation.getStatus());
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -9,6 +9,8 @@ import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.service.ReservationService;
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationCancelRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationCreateRequest;
 import org.pgsg.reservation.presentation.dto.request.ReservationSearchRequest;
@@ -143,5 +145,27 @@ public class ReservationController {
         ReservationCancelResponse response = ReservationCancelResponse.of(info, "판매자 사유 취소가 완료되었습니다.");
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 예약 만료(관리자만 조정 가능)
+    @PatchMapping("/{reservationId}/admin-force")
+    public ResponseEntity<ReservationCancelResponse> expireByAdmin(
+            @PathVariable UUID reservationId,
+            @RequestBody ReservationAdminCancelRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReservationCancelInfo info = reservationService.expireByAdmin(
+                reservationId,
+                request,
+                userDetails.getUuid(),
+                userDetails.getUserRole()
+        );
+
+        // targetStatus에 따른 맞춤형 메시지 생성
+        String message = (request.targetStatus() == ReservationStatus.CANCELLED_BY_BUYER)
+                ? "관리자 권한으로 구매자 사유 취소(승계) 처리가 완료되었습니다."
+                : "관리자 권한으로 판매자 사유 취소(종료) 처리가 완료되었습니다.";
+
+        return ResponseEntity.ok(ReservationCancelResponse.of(info, message));
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationAdminCancelRequest.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationAdminCancelRequest.java
@@ -1,0 +1,8 @@
+package org.pgsg.reservation.presentation.dto.request;
+
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+
+public record ReservationAdminCancelRequest(
+        ReservationStatus targetStatus,
+        String reason
+) {}


### PR DESCRIPTION
### 작업 배경
- 예약 만료 기능 구현

### 작업 내용
- 예약 만료시 관리자가 판매자,구매자 사유에 따른 변경 기능 구현
- 스케줄링 활용하여 상태 변경후 1시간 동안 다른 상태로 변경되지 않을 시 시스템 적으로 처리

### 테스트 여부
- .\gradlew clean build -x test 통과 확인

### 기타
- 추후 상품과 이벤트 연결 할 예정입니다

### 이슈
>  This closes #17 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 예약을 강제로 만료·취소할 수 있는 API가 추가되었습니다 (대상 상태 및 사유 지정 가능).
  * 수정된 지 60분 이상 경과한 대기·결제 예약을 자동으로 만료시키는 스케줄러가 도입되었습니다.
  * 관리자 조치 후 반환되는 취소/만료 정보와 상황별 응답 메시지가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->