### PR TITLE
feat : 예약 만료 구현

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -65,7 +65,7 @@ public class ReservationService {
         // DB 저장
         Reservation savedReservation = reservationRepository.save(reservation);
 
-        // 5. [결과 반환] Result DTO로 변환하여 Controller로 전달
+        // [결과 반환] Result DTO로 변환하여 Controller로 전달
         return ReservationCreateResult.builder()
                 .reservationId(savedReservation.getId())
                 .status(savedReservation.getStatus().name())
@@ -196,6 +196,19 @@ public class ReservationService {
                 request.targetStatus(),
                 request.reason()
         );
+
+        reservationHistoryRepository.save(history);
+
+        return ReservationCancelInfo.from(reservation);
+    }
+
+    // 예약 완료
+    @Transactional
+    public ReservationCancelInfo completeReservation(UUID reservationId, UUID userId, String role) {
+        // 예약 엔티티 조회
+        Reservation reservation = findById(reservationId);
+
+        ReservationHistory history = reservationDomainService.completeReservation(reservation,userId,role);
 
         reservationHistoryRepository.save(history);
 

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -212,6 +212,32 @@ public class ReservationDomainService {
     }
 
     /**
+     * 예약 완료
+     * 예약 완료 도메인 로직 및 이력 객체 생성
+     */
+    public ReservationHistory completeReservation(Reservation reservation, UUID userId ,String role) {
+        // 권한 검증 로직
+        if (!role.equals("ADMIN") && !reservation.getSellerInfo().getSellerId().equals(userId)) {
+            throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        ReservationStatus previousStatus = reservation.getStatus();
+
+        // 엔티티 비즈니스 로직 실행 (PAID -> COMPLETED)
+        // 규칙: 예약 대기 상태일 때만 완료 가능
+        reservation.complete();
+
+        // 저장할 이력 객체 생성 및 반환
+        return ReservationHistory.of(
+                reservation.getId(),
+                previousStatus,
+                ReservationStatus.COMPLETED,
+                "판매자 채팅 수락으로 인한 예약 완료",
+                userId
+        );
+    }
+
+    /**
      * 다음 구매자 승계 내부 로직
      */
     private void handleNextBuyerSequence(Reservation reservation) {
@@ -236,4 +262,5 @@ public class ReservationDomainService {
             throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
         }
     }
+
 }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -9,10 +9,7 @@ import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandida
 import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 
 @Service
@@ -217,7 +214,9 @@ public class ReservationDomainService {
      */
     public ReservationHistory completeReservation(Reservation reservation, UUID userId ,String role) {
         // 권한 검증 로직
-        if (!role.equals("ADMIN") && !reservation.getSellerInfo().getSellerId().equals(userId)) {
+        boolean isSeller = reservation.getSellerInfo() != null && Objects.equals(reservation.getSellerInfo().getSellerId(), userId);
+        boolean isAdmin = "ADMIN".equalsIgnoreCase(role);
+        if (!isAdmin && !isSeller) {
             throw new ReservationException(ReservationErrorCode.UNAUTHORIZED_ACCESS);
         }
 

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -148,7 +148,7 @@ public class ReservationController {
     }
 
     // 예약 만료(관리자만 조정 가능)
-    @PatchMapping("/{reservationId}/admin-force")
+    @PatchMapping("/{reservationId}/expire")
     public ResponseEntity<ReservationCancelResponse> expireByAdmin(
             @PathVariable UUID reservationId,
             @RequestBody ReservationAdminCancelRequest request,
@@ -161,10 +161,26 @@ public class ReservationController {
                 userDetails.getUserRole()
         );
 
-        // targetStatus에 따른 맞춤형 메시지 생성
         String message = (request.targetStatus() == ReservationStatus.CANCELLED_BY_BUYER)
                 ? "관리자 권한으로 구매자 사유 취소(승계) 처리가 완료되었습니다."
                 : "관리자 권한으로 판매자 사유 취소(종료) 처리가 완료되었습니다.";
+
+        return ResponseEntity.ok(ReservationCancelResponse.of(info, message));
+    }
+
+    // 예약 완료
+    @PatchMapping("/{reservationId}/complete")
+    public ResponseEntity<ReservationCancelResponse> completeReservation(
+            @PathVariable UUID reservationId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReservationCancelInfo info = reservationService.completeReservation(
+                reservationId,
+                userDetails.getUuid(),
+                userDetails.getUserRole()
+        );
+
+        String message = "판매자 채팅 수락에 따라 예약 완료 처리가 완료되었습니다.";
 
         return ResponseEntity.ok(ReservationCancelResponse.of(info, message));
     }


### PR DESCRIPTION
### 작업 배경
- 예약 만료 기능 구현

### 작업 내용
- 예약 만료 기능 구현

### 테스트 여부
- .\gradlew clean build -x test 통과 확인

### 기타
- 해당 작업까지 완료되면 kafka 연결 및 리펙토링 예정입니다

### 이슈
> This closes #19 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 예약 완료 기능이 추가되어 관리자/판매자 권한으로 예약을 완료하고 완료 관련 정보를 응답받을 수 있습니다. 완료 시 고정된 완료 메시지가 함께 반환됩니다.
  * 예약 만료 관련 관리자 엔드포인트가 경로가 재정의되어(기존 관리자 강제 처리 경로 대체) 만료 처리를 수행합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->