### PR TITLE
Feat : 예약 생성 개념 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,38 @@
-# 1. 빌드 단계
+# 빌드 단계
 FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
 
-# 소스 코드 전체 복사 (gradle.properties 포함)
+# 소스 코드 복사
 COPY . .
 
-# gradlew 실행 권한 부여
+# gradlew 실행 권한 부여 및 빌드 (plain jar 생성 방지 설정이 없으면 필터링 필요)
 RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar -x test
 
-# 빌드 실행 (이미 파일에 인증 정보가 있으므로 추가 인자 없이 실행 가능)
-# 만약 빌드 시점에 값을 주입하고 싶다면 그대로 두셔도 무방합니다.
-RUN ./gradlew bootJar -x test
-
-# 2. 실행 단계
+# 실행 단계
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
-# 빌드 결과물 복사
-COPY --from=build /app/build/libs/*.jar app.jar
+# 보안을 위해 실행 단계에서 사용자 생성
+RUN addgroup -S appuser && adduser -S appuser -G appuser
 
-# SSL 인증서 경로 설정 (yml 설정인 /app/ssl/ 경로와 일치시킴)
+# 빌드 결과물 복사 (plain.jar를 제외하고 딱 하나만 복사되도록 명시)
+COPY --from=build /app/build/libs/*-SNAPSHOT.jar app.jar
+# 또는 명확하게 하나만 남도록 빌드 설정이 되어있다면 그대로 사용 가능합니다.
+
+# SSL 인증서 폴더 생성 및 복사
 RUN mkdir -p /app/ssl
+# 파일이 있을 때만 복사하도록 구성하거나, 확실히 존재해야 함을 명시
 COPY src/main/resources/ssl/*.jks /app/ssl/
+
+# 권한 설정 (사용자 생성 후 일괄 변경)
+RUN chown -R appuser:appuser /app
 
 # 환경 변수 및 포트 설정
 ENV SPRING_PROFILES_ACTIVE=dev
 EXPOSE 8085
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+USER appuser
+
+# 최적화된 Java 실행 옵션 (Container 환경 인식)
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,29 @@
+# 1. 빌드 단계
 FROM eclipse-temurin:21-jdk-alpine AS build
 WORKDIR /app
 
+# 소스 코드 전체 복사 (gradle.properties 포함)
 COPY . .
 
+# gradlew 실행 권한 부여
 RUN chmod +x ./gradlew
 
-RUN --mount=type=secret,id=GPR_USER \
-    --mount=type=secret,id=GPR_TOKEN \
-    GPR_USER=$(cat /run/secrets/GPR_USER) && \
-    GPR_TOKEN=$(cat /run/secrets/GPR_TOKEN) && \
-    ./gradlew bootJar -x test \
-    -Pgpr.user="${GPR_USER}" \
-    -Pgpr.token="${GPR_TOKEN}"
+# 빌드 실행 (이미 파일에 인증 정보가 있으므로 추가 인자 없이 실행 가능)
+# 만약 빌드 시점에 값을 주입하고 싶다면 그대로 두셔도 무방합니다.
+RUN ./gradlew bootJar -x test
 
+# 2. 실행 단계
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 
 # 빌드 결과물 복사
 COPY --from=build /app/build/libs/*.jar app.jar
 
-# SSL 인증서 등 리소스 복사
-RUN mkdir -p /app/resources
-COPY src/main/resources/ssl/*.jks /app/resources/
+# SSL 인증서 경로 설정 (yml 설정인 /app/ssl/ 경로와 일치시킴)
+RUN mkdir -p /app/ssl
+COPY src/main/resources/ssl/*.jks /app/ssl/
 
+# 환경 변수 및 포트 설정
 ENV SPRING_PROFILES_ACTIVE=dev
 EXPOSE 8085
 

--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
@@ -2,12 +2,18 @@ package org.pgsg.reservation.application.dto.command;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
 @Builder
 public class ReservationCreateCommand {
     private UUID productId;
-    private UUID buyerId;
-    private String buyerNickname;
+
+    private UUID sellerId;      // 판매자 ID
+    private String sellerName;  // 판매자 이름 (또는 닉네임)
+    private String productName; // 상품명
+    private Integer price;      // 가격
+    private LocalDateTime endTime; // 종료 시간
 }

--- a/src/main/java/org/pgsg/reservation/application/dto/event/ReservationCompletedEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/ReservationCompletedEvent.java
@@ -1,11 +1,8 @@
 package org.pgsg.reservation.application.dto.event;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
-
 import java.util.UUID;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record ReservationCompletedEvent(
         UUID reservationId,
         UUID productId,
@@ -24,8 +21,8 @@ public record ReservationCompletedEvent(
                 reservation.getProductInfo().getProductPrice(),
                 reservation.getSellerInfo().getSellerId(),
                 reservation.getSellerInfo().getSellerName(),
-                reservation.getBuyerInfo().getBuyerId(),
-                reservation.getBuyerInfo().getBuyerName()
+                reservation.getBuyerInfo() != null ? reservation.getBuyerInfo().getBuyerId() : null,
+                reservation.getBuyerInfo() != null ? reservation.getBuyerInfo().getBuyerName() : "Unknown"
         );
     }
 }

--- a/src/main/java/org/pgsg/reservation/application/dto/event/TimeDealProductEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/TimeDealProductEvent.java
@@ -1,18 +1,24 @@
 package org.pgsg.reservation.application.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty; // 추가됨
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record TimeDealProductEvent(
         UUID productId,
+
+        @JsonProperty("productName")
         String name,
+
+        @JsonProperty("productPrice")
         Integer price,
 
-        // JSON 배열 [YYYY, M, D, H, m, s] 형식을 LocalDateTime으로 매핑
         @JsonFormat(shape = JsonFormat.Shape.ARRAY)
         LocalDateTime endTime,
 
         UUID sellerId,
+
+        @JsonProperty("sellerNickName")
         String sellerName
 ) {}

--- a/src/main/java/org/pgsg/reservation/application/dto/event/TimeDealProductEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/TimeDealProductEvent.java
@@ -1,0 +1,18 @@
+package org.pgsg.reservation.application.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TimeDealProductEvent(
+        UUID productId,
+        String name,
+        Integer price,
+
+        // JSON 배열 [YYYY, M, D, H, m, s] 형식을 LocalDateTime으로 매핑
+        @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+        LocalDateTime endTime,
+
+        UUID sellerId,
+        String sellerName
+) {}

--- a/src/main/java/org/pgsg/reservation/application/dto/result/ReservationCreateResult.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/result/ReservationCreateResult.java
@@ -2,6 +2,9 @@ package org.pgsg.reservation.application.dto.result;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.pgsg.reservation.domain.model.reservation.Reservation;
+
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -9,4 +12,19 @@ import java.util.UUID;
 public class ReservationCreateResult {
     private UUID reservationId;
     private String status;
+    private String productName;
+    private String sellerName;
+    private String buyerName;
+    private LocalDateTime createdAt;
+
+    public static ReservationCreateResult from(Reservation reservation) {
+        return ReservationCreateResult.builder()
+                .reservationId(reservation.getId())
+                .status(reservation.getStatus().name())
+                .productName(reservation.getProductInfo().getProductName())
+                .sellerName(reservation.getSellerInfo().getSellerName())
+                .buyerName(reservation.getBuyerInfo() != null ? reservation.getBuyerInfo().getBuyerName() : null)
+                .createdAt(reservation.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -38,7 +38,6 @@ public class ReservationService {
     private final ReservationDomainService reservationDomainService;
     private final ReservationHistoryRepository reservationHistoryRepository;
     private final ReservationEventPublisher reservationEventPublisher;
-    // private final ProductClient productClient; // 추후 구현 예정
 
     // 도메인 서비스 호출 전까지의 작업은 트랜잭션 밖으로 분리(추후 고도화 작업시)
     @Transactional

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -43,34 +43,33 @@ public class ReservationService {
     // 도메인 서비스 호출 전까지의 작업은 트랜잭션 밖으로 분리(추후 고도화 작업시)
     @Transactional
     public ReservationCreateResult createReservation(ReservationCreateCommand command) {
-        // 중복 검증
-        if (reservationRepository.existsByProductId(command.getProductId())) {
-            throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
+        try {
+            if (reservationRepository.existsByProductId(command.getProductId())) {
+                throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
+            }
+
+            SellerInfo seller = SellerInfo.of(command.getSellerId(), "test");
+            ProductInfo product = ProductInfo.of(
+                    command.getProductId(),
+                    command.getPrice(),
+                    command.getProductName(),
+                    command.getEndTime()
+            );
+
+            Reservation reservation = reservationDomainService.createReservation(
+                    seller,
+                    product,
+                    command.getEndTime()
+            );
+
+            Reservation saved = reservationRepository.save(reservation);
+
+            return ReservationCreateResult.from(saved);
+
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
         }
-
-        // VO 생성
-        SellerInfo seller = SellerInfo.of(command.getSellerId(), "test"); // 추후 수정 필요함(user-service연결 혹은 product에서 받아야함)
-        ProductInfo product = ProductInfo.of(
-                command.getProductId(),
-                command.getPrice(),
-                command.getProductName(),
-                command.getEndTime()
-        );
-
-        // 도메인 서비스 호출 (buyer는 null로 전달)
-        Reservation reservation = reservationDomainService.createReservation(
-                seller,
-                product,
-                command.getEndTime()
-        );
-
-        Reservation saved = reservationRepository.save(reservation);
-
-        // 저장 및 결과 반환
-        return ReservationCreateResult.builder()
-                .reservationId(saved.getId())
-                .status(saved.getStatus().name())
-                .build();
     }
 
     // 예약 목록 조회

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -61,7 +61,12 @@ public class ReservationService {
                     command.getEndTime()
             );
 
-            Reservation saved = reservationRepository.save(reservation);
+            Reservation saved;
+            try {
+                saved = reservationRepository.save(reservation);
+            }catch (DataIntegrityViolationException e) {
+                throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
+            }
 
             return ReservationCreateResult.from(saved);
 

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -1,6 +1,7 @@
 package org.pgsg.reservation.application.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
 import org.pgsg.reservation.application.dto.event.ReservationEventPublisher;
@@ -30,6 +31,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
@@ -41,36 +43,33 @@ public class ReservationService {
     // 도메인 서비스 호출 전까지의 작업은 트랜잭션 밖으로 분리(추후 고도화 작업시)
     @Transactional
     public ReservationCreateResult createReservation(ReservationCreateCommand command) {
+        // 중복 검증
+        if (reservationRepository.existsByProductId(command.getProductId())) {
+            throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
+        }
 
-        // 구매자 정보(VO) 생성
-        BuyerInfo buyer = BuyerInfo.of(command.getBuyerId(), command.getBuyerNickname());
-
-        // 상품 및 판매자 정보 조회(추후 구현 예정)
-        // ProductResponse productResponse = productClient.getProductDetails(command.getProductId());
-
-        // 임시로 생성(추후 상품 판매 정보 조회시 수정 필요)
-        SellerInfo seller = SellerInfo.of(
-                UUID.randomUUID(), // productResponse.getSellerId()
-                "임시 판매자" // productResponse.getSellerName()
-        );
+        // VO 생성
+        SellerInfo seller = SellerInfo.of(command.getSellerId(), "test"); // 추후 수정 필요함(user-service연결 혹은 product에서 받아야함)
         ProductInfo product = ProductInfo.of(
                 command.getProductId(),
-                50000,             // productResponse.getPrice()
-                "타임딜 특가 상품"    // productResponse.getName()
+                command.getPrice(),
+                command.getProductName(),
+                command.getEndTime()
         );
 
-        // 도메인 서비스 호출
-        Reservation reservation = reservationDomainService.createReservation(buyer, seller, product);
+        // 도메인 서비스 호출 (buyer는 null로 전달)
+        Reservation reservation = reservationDomainService.createReservation(
+                seller,
+                product,
+                command.getEndTime()
+        );
 
-        // ransaction outbox 패턴에 기반한 이벤트 발송 로직 추가 예정
+        Reservation saved = reservationRepository.save(reservation);
 
-        // DB 저장
-        Reservation savedReservation = reservationRepository.save(reservation);
-
-        // [결과 반환] Result DTO로 변환하여 Controller로 전달
+        // 저장 및 결과 반환
         return ReservationCreateResult.builder()
-                .reservationId(savedReservation.getId())
-                .status(savedReservation.getStatus().name())
+                .reservationId(saved.getId())
+                .status(saved.getStatus().name())
                 .build();
     }
 

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -70,9 +70,9 @@ public class ReservationService {
 
             return ReservationCreateResult.from(saved);
 
-        } catch (Throwable t) {
-            t.printStackTrace();
-            throw t;
+        } catch (DataIntegrityViolationException e) {
+            // 동시에 들어온 요청으로 인해 유니크 제약 조건 위반 시 409 에러 발생
+            throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
         }
     }
 

--- a/src/main/java/org/pgsg/reservation/domain/exception/ReservationErrorCode.java
+++ b/src/main/java/org/pgsg/reservation/domain/exception/ReservationErrorCode.java
@@ -21,7 +21,8 @@ public enum ReservationErrorCode {
 
     // 409 Conflict (중복 등 비즈니스 규칙 위반)
     DUPLICATE_RESERVATION(409, "이미 해당 상품에 대한 예약 진행 내역이 존재합니다."),
-    ALREADY_APPLIED(409, "이미 해당 예약에 신청한 후보자입니다.");
+    ALREADY_APPLIED(409, "이미 해당 예약에 신청한 후보자입니다."),
+    ALREADY_EXISTS(409, "해당 상품으로 이미 생성된 예약 데이터가 존재합니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
@@ -1,5 +1,6 @@
 package org.pgsg.reservation.domain.model.reservation;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
@@ -11,6 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(staticName = "of")
 public class ProductInfo {
+    @Column(nullable = false, unique = true)
     private UUID productId;
     private Integer productPrice;
     private String productName;

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
@@ -2,6 +2,8 @@ package org.pgsg.reservation.domain.model.reservation;
 
 import jakarta.persistence.Embeddable;
 import lombok.*;
+
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Embeddable
@@ -12,4 +14,5 @@ public class ProductInfo {
     private UUID productId;
     private Integer productPrice;
     private String productName;
+    private LocalDateTime endTime;
 }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/ProductInfo.java
@@ -16,5 +16,6 @@ public class ProductInfo {
     private UUID productId;
     private Integer productPrice;
     private String productName;
+    @Column(nullable = false)
     private LocalDateTime endTime;
 }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
@@ -8,6 +8,7 @@ import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
 import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidateStatus;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Entity
@@ -55,15 +56,17 @@ public class Reservation extends BaseEntity {
     }
 
     // 예약 생성: 초기 상태 AVAILABLE
-    public static Reservation create(BuyerInfo buyer, SellerInfo seller, ProductInfo product) {
-        Objects.requireNonNull(buyer, "buyer must not be null");
+    public static Reservation create(BuyerInfo buyer, SellerInfo seller, ProductInfo product, LocalDateTime endTime) {
         Objects.requireNonNull(seller, "seller must not be null");
         Objects.requireNonNull(product, "product must not be null");
+
         Reservation reservation = new Reservation();
         reservation.buyerInfo = buyer;
         reservation.sellerInfo = seller;
         reservation.productInfo = product;
         reservation.status = ReservationStatus.AVAILABLE;
+        reservation.createdAt = LocalDateTime.now();
+
         return reservation;
     }
 

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
@@ -29,6 +29,10 @@ public class Reservation extends BaseEntity {
     private ReservationStatus status;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "buyerId", column = @Column(name = "buyer_id", nullable = true)),
+            @AttributeOverride(name = "buyerName", column = @Column(name = "buyer_name", nullable = true))
+    })
     private BuyerInfo buyerInfo;
 
     @Embedded

--- a/src/main/java/org/pgsg/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/org/pgsg/reservation/domain/repository/ReservationRepository.java
@@ -24,4 +24,7 @@ public interface ReservationRepository {
 
     // 예약 만료 스케줄링용
     List<Reservation> findAllByStatusInAndModifiedAtBefore(List<ReservationStatus> statuses, LocalDateTime threshold);
+
+    // 상품 존재 여부 확인
+    boolean existsByProductId(UUID productId);
 }

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationDomainService.java
@@ -9,6 +9,7 @@ import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandida
 import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 
@@ -22,11 +23,13 @@ public class ReservationDomainService {
      * 예약 생성 로직
      * 각 VO들을 조합하여 예약 엔티티를 생성하고, 도메인 규칙을 검증
      */
-    public Reservation createReservation(BuyerInfo buyer, SellerInfo seller, ProductInfo product) {
+    public Reservation createReservation(SellerInfo seller, ProductInfo product, LocalDateTime endTime) {
 
-        reservationValidator.validate(buyer, seller, product);
+        // 검증 로직
+        reservationValidator.validate(seller, product);
 
-        return Reservation.create(buyer, seller, product);
+        // 엔티티 생성
+        return Reservation.create(null, seller, product, endTime);
     }
 
     /**

--- a/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
+++ b/src/main/java/org/pgsg/reservation/domain/service/ReservationValidator.java
@@ -11,22 +11,11 @@ import java.util.UUID;
 
 public class ReservationValidator {
 
-    public void validate(BuyerInfo buyer, SellerInfo seller, ProductInfo product) {
-
-        if (buyer == null || seller == null || product == null) {
+    // 예약 생성
+    public void validate(SellerInfo seller, ProductInfo product) {
+        if (seller == null || product == null || seller.getSellerId() == null) {
             throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
         }
-
-        if (buyer.getBuyerId() == null || seller.getSellerId() == null) {
-            throw new ReservationException(ReservationErrorCode.INVALID_INPUT);
-        }
-
-        // 본인 상품 예약 금지 규칙
-        if (isSamePerson(buyer, seller)) {
-            throw new ReservationException(ReservationErrorCode.INVALID_STATUS);
-        }
-
-        // 검증 규칙 추가 예정
     }
 
     public void validateSearchRequest(UUID userId, String role) {
@@ -80,5 +69,4 @@ public class ReservationValidator {
     private boolean isSamePerson(BuyerInfo buyer, SellerInfo seller) {
         return buyer.getBuyerId().equals(seller.getSellerId());
     }
-
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -1,0 +1,35 @@
+package org.pgsg.reservation.infrastructure.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
+import org.pgsg.reservation.application.dto.event.TimeDealProductEvent;
+import org.pgsg.reservation.application.service.ReservationService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductListener {
+
+    private final ReservationService reservationService;
+
+    /**
+     * 상품 서비스에서 타임딜 상품이 생성되었을 때의 이벤트를 수신합니다.
+     */
+    @KafkaListener(topics = "time-deal-topic")
+    public void handleTimeDealEvent(TimeDealProductEvent event) {
+        ReservationCreateCommand command = ReservationCreateCommand.builder()
+                .productId(event.productId())
+                .productName(event.name())
+                .price(event.price())
+                .endTime(event.endTime())
+                .sellerId(event.sellerId())
+                .sellerName(event.sellerName())
+                .build();
+
+        reservationService.createReservation(command);
+    }
+
+}

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -18,7 +18,7 @@ public class ProductListener {
     /**
      * 상품 서비스에서 타임딜 상품이 생성되었을 때의 이벤트를 수신합니다.
      */
-    @KafkaListener(topics = "time-deal-topic",groupId = "product-group")
+    @KafkaListener(topics = "prod-product-created",groupId = "product-group")
     public void handleTimeDealEvent(TimeDealProductEvent event) {
         ReservationCreateCommand command = ReservationCreateCommand.builder()
                 .productId(event.productId())

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -18,7 +18,7 @@ public class ProductListener {
     /**
      * 상품 서비스에서 타임딜 상품이 생성되었을 때의 이벤트를 수신합니다.
      */
-    @KafkaListener(topics = "time-deal-topic")
+    @KafkaListener(topics = "time-deal-topic",groupId = "product-group")
     public void handleTimeDealEvent(TimeDealProductEvent event) {
         ReservationCreateCommand command = ReservationCreateCommand.builder()
                 .productId(event.productId())

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
 import org.pgsg.reservation.application.dto.event.TimeDealProductEvent;
 import org.pgsg.reservation.application.service.ReservationService;
+import org.pgsg.reservation.domain.exception.ReservationErrorCode;
+import org.pgsg.reservation.domain.exception.ReservationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +31,15 @@ public class ProductListener {
                 .sellerName(event.sellerName())
                 .build();
 
-        reservationService.createReservation(command);
+        try {
+            reservationService.createReservation(command);
+        }catch (ReservationException e){
+            if (e.getErrorCode() == ReservationErrorCode.ALREADY_EXISTS) {
+                log.info("중복 예약 생성 이벤트 무시: productId={}", event.productId());
+                return;
+            }
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/JpaReservationRepository.java
@@ -1,12 +1,10 @@
 package org.pgsg.reservation.infrastructure.repository.reservation;
 
 import org.pgsg.reservation.domain.model.reservation.Reservation;
-import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 public interface JpaReservationRepository extends JpaRepository<Reservation, UUID> {
+    boolean existsByProductInfoProductId(UUID productId);
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -41,6 +41,11 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     @Override
+    public boolean existsByProductId(UUID productId) {
+        return reservationJpaRepository.existsByProductInfoProductId(productId);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public List<Reservation> findAllByStatusInAndModifiedAtBefore(
             List<ReservationStatus> statuses,

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -36,15 +36,15 @@ public class ReservationController {
     // 예약 생성
     @PostMapping
     public ResponseEntity<ReservationResponse> createReservation(
-            @Valid @RequestBody ReservationCreateRequest request,
-            @RequestHeader(value = "X-User-Id") UUID userId,
-            @RequestHeader(value = "X-User-Nickname") String nickname
+            @Valid @RequestBody ReservationCreateRequest request
     ) {
-
         ReservationCreateCommand command = ReservationCreateCommand.builder()
                 .productId(request.getProductId())
-                .buyerId(userId)
-                .buyerNickname(nickname)
+                .productName(request.getProductName())
+                .price(request.getPrice())
+                .endTime(request.getEndTime())
+                .sellerId(request.getSellerId())
+                .sellerName(request.getSellerNickname())
                 .build();
 
         ReservationCreateResult result = reservationService.createReservation(command);

--- a/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationCreateRequest.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/request/ReservationCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -12,4 +13,20 @@ public class ReservationCreateRequest {
 
     @NotNull(message = "상품 ID는 필수입니다.")
     private UUID productId;
+
+    @NotNull(message = "상품 이름은 필수입니다.")
+    private String productName;
+
+    @NotNull(message = "가격은 필수입니다.")
+    private Integer price;
+
+    @NotNull(message = "종료 시간은 필수 입니다.")
+    private LocalDateTime endTime;
+
+    @NotNull(message = "판매자 ID는 필수입니다.")
+    private UUID sellerId;
+
+    @NotNull(message = "판매자 닉네임은 필수입니다.")
+    private String sellerNickname;
+
 }

--- a/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationResponse.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationResponse.java
@@ -1,5 +1,6 @@
 package org.pgsg.reservation.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReservationResponse {
 
     private UUID reservationId;
@@ -31,6 +33,9 @@ public class ReservationResponse {
         return ReservationResponse.builder()
                 .reservationId(result.getReservationId())
                 .status(result.getStatus())
+                .productName(result.getProductName())
+                .sellerName(result.getSellerName())
+                .buyerName(result.getBuyerName())
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
       ssl.endpoint.identification.algorithm: ""
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
   # [필수 5] Redis 설정
   data:


### PR DESCRIPTION
### 작업 배경
- 예약 생성 개념 변경으로 인한 기능 재구성

### 작업 내용
- 예약 생성 구조 변경

### 테스트 여부
-docker-compose up -d --build reservation-service 성공 및 데이터 저장 확인

### 기타
- 아직 상품에서 kafka받는건 테스트를 안해봐서 추후 테스트 예정입니다

### 이슈
> This closes #24 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 타임딜 상품 이벤트 기반 예약 자동 생성 리스너 추가
  * 예약 생성 요청에 상품명·가격·종료시간·판매자 정보 포함

* **버그 수정**
  * 동일 상품 중복 예약 방지(409 처리 및 존재 확인)
  * 응답에 상품명·판매자명·구매자명 반영 및 null 값 미포함 처리
  * 예약 생성 시 더 이상 사용자 헤더를 요구하지 않음

* **Chores**
  * Docker 런타임 보안/시작 방식 개선(비루트 실행, 컨테이너 최적화 옵션, SSL 키스토어 위치 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->