### PR TITLE
Feat/26 reservation tradeconfirm

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
-import org.pgsg.reservation.application.dto.event.ReservationEventPublisher;
+import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublisher;
 import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
@@ -221,6 +221,18 @@ public class ReservationService {
         return ReservationCancelInfo.from(reservation);
     }
 
+    // 거래 완료
+    @Transactional
+    public ReservationCancelInfo confirmTrade(UUID reservationId) {
+
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        reservation.close();
+
+        return ReservationCancelInfo.from(reservation);
+    }
+
     /**
      * 공통 ID 조회 메서드
      */
@@ -233,5 +245,4 @@ public class ReservationService {
         String message = e.getMostSpecificCause().getMessage();
         return message != null && message.contains("uk_reservation_candidate_user_id");
     }
-
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.pgsg.common.event.Events;
 import org.pgsg.common.event.OutboxEvent;
 import org.pgsg.reservation.application.dto.event.ReservationCompletedEvent;
-import org.pgsg.reservation.application.dto.event.ReservationEventPublisher;
+import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublisher;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -1,9 +1,12 @@
 package org.pgsg.reservation.infrastructure.listener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.pgsg.common.messaging.annotation.IdempotentConsumer;
 import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
-import org.pgsg.reservation.application.dto.event.TimeDealProductEvent;
+import org.pgsg.reservation.infrastructure.listener.dto.TimeDealProductEvent;
 import org.pgsg.reservation.application.service.ReservationService;
 import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.exception.ReservationException;
@@ -16,29 +19,42 @@ import org.springframework.stereotype.Component;
 public class ProductListener {
 
     private final ReservationService reservationService;
+    private final ObjectMapper objectMapper;
 
     /**
      * 상품 서비스에서 타임딜 상품이 생성되었을 때의 이벤트를 수신합니다.
      */
+    @IdempotentConsumer("product-completed:product-service")
     @KafkaListener(topics = "prod-product-created",groupId = "product-group")
-    public void handleTimeDealEvent(TimeDealProductEvent event) {
-        ReservationCreateCommand command = ReservationCreateCommand.builder()
-                .productId(event.productId())
-                .productName(event.name())
-                .price(event.price())
-                .endTime(event.endTime())
-                .sellerId(event.sellerId())
-                .sellerName(event.sellerName())
-                .build();
+    public void handleTimeDealEvent(ConsumerRecord<String, String> record) {
+        TimeDealProductEvent event = null;
 
         try {
+            event = objectMapper.readValue(record.value(), TimeDealProductEvent.class);
+            log.info("타임딜 상품 생성 이벤트 수신 - Product ID: {}, Name: {}",
+                    event.productId(), event.name());
+
+            ReservationCreateCommand command = ReservationCreateCommand.builder()
+                    .productId(event.productId())
+                    .productName(event.name())
+                    .price(event.price())
+                    .endTime(event.endTime())
+                    .sellerId(event.sellerId())
+                    .sellerName(event.sellerName())
+                    .build();
+
             reservationService.createReservation(command);
-        }catch (ReservationException e){
+        }catch (ReservationException e) {
             if (e.getErrorCode() == ReservationErrorCode.ALREADY_EXISTS) {
-                log.info("중복 예약 생성 이벤트 무시: productId={}", event.productId());
+                log.info("중복 예약 생성 이벤트 무시: productId={}",
+                        (event != null) ? event.productId() : "Unknown");
                 return;
             }
-            throw e;
+            log.error("예약 생성 중 비즈니스 오류 발생: {}", e.getMessage());
+            throw e; // 재시도가 필요한 경우 던짐
+        } catch (Exception e) {
+            log.error("상품 생성 이벤트 처리 실패 - Topic: {}, Error: {}",
+                    record.topic(), e.getMessage());
         }
     }
 

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
@@ -1,0 +1,46 @@
+package org.pgsg.reservation.infrastructure.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.pgsg.common.messaging.annotation.IdempotentConsumer;
+import org.pgsg.reservation.application.service.ReservationService;
+import org.pgsg.reservation.infrastructure.listener.dto.TradeCompletedEvent;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+
+    private final ReservationService reservationService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 거래 서비스로부터 거래 완료 이벤트를 수신
+     */
+    @IdempotentConsumer("reservation-completed:trade-service")
+    @KafkaListener(
+            topics = "prod-trade-completed",
+            groupId = "reservation-group"
+    )
+    public void handleTradeCompleted(ConsumerRecord<String, String> record) {
+
+        try {
+            TradeCompletedEvent event = objectMapper.readValue(record.value(), TradeCompletedEvent.class);
+            log.info("거래 완료 이벤트 수신 - Trade ID: {}, Reservation ID: {}",
+                    event.tradeId(), event.reservationId());
+            reservationService.confirmTrade(
+                    event.reservationId()
+            );
+
+            log.info("예약 확정 처리 성공 - Reservation ID: {}", event.reservationId());
+        }catch (Exception e) {
+            log.error("예약 확정 처리 실패 - Reservation ID: {}, Error: {}",
+                    record.topic(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/ReservationEventPublisher.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/ReservationEventPublisher.java
@@ -1,4 +1,4 @@
-package org.pgsg.reservation.application.dto.event;
+package org.pgsg.reservation.infrastructure.listener.dto;
 
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/TimeDealProductEvent.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/TimeDealProductEvent.java
@@ -1,4 +1,4 @@
-package org.pgsg.reservation.application.dto.event;
+package org.pgsg.reservation.infrastructure.listener.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty; // 추가됨
@@ -8,10 +8,8 @@ import java.util.UUID;
 public record TimeDealProductEvent(
         UUID productId,
 
-        @JsonProperty("productName")
         String name,
 
-        @JsonProperty("productPrice")
         Integer price,
 
         @JsonFormat(shape = JsonFormat.Shape.ARRAY)

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/TradeCompletedEvent.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/TradeCompletedEvent.java
@@ -1,0 +1,9 @@
+package org.pgsg.reservation.infrastructure.listener.dto;
+
+import java.util.UUID;
+
+public record TradeCompletedEvent(
+        UUID tradeId,
+        UUID reservationId,
+        UUID productId
+) {}

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -186,4 +186,20 @@ public class ReservationController {
 
         return ResponseEntity.ok(ReservationCancelResponse.of(info, message));
     }
+
+    // 거래 완료
+    @PatchMapping("/{reservationId}/tradeconfirm")
+    public ResponseEntity<ReservationCancelResponse> confirmTrade(
+            @PathVariable UUID reservationId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Role") String role
+    ) {
+        ReservationCancelInfo info = reservationService.confirmTrade(
+                reservationId
+        );
+
+        String message = "거래가 성공적으로 완료되어 확정 처리되었습니다.";
+
+        return ResponseEntity.ok(ReservationCancelResponse.of(info, message));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: reservation-service
 
   profiles:
-    active: dev , kafka
+    active: dev,kafka
     include: error, reservation-error
 
   # [필수 1] 설정 로드 순서
@@ -55,7 +55,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    show-sql: ${SPRING_JPA_SHOW_SQL:false}
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
     defer-datasource-initialization: true
 
 management:
@@ -84,3 +88,11 @@ eureka:
 topics:
   reservation:
     completed: prod-reservation-completed
+  product:
+    created: prod-product-created
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    org.pgsg.common.domain.OutboxRepository: OFF


### PR DESCRIPTION
### 작업 배경
- 거래 확인 이벤트로 받아 처리

### 작업 내용
-  거래 확인 이벤트로 받아 처리

### 테스트 여부
- docker-compose up -d --build reservation-service

### 기타
- ex) 기능 구현 위주로 개발하여 추후 ~~~~ 방식으로 리팩토링할 예정입니다. 
			참고해서 리뷰 부탁드려요!

### 이슈
> This closes #26 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 예약 생성, 검색, 상세 조회 기능 추가
  * 예약 후보자 신청 및 선정 시스템 구현
  * 구매자/판매자/관리자의 예약 취소 기능
  * 예약 완료 및 거래 확정 기능
  * 자동 만료 스케줄러로 시간 초과 예약 자동 처리
  * 이벤트 기반 아키텍처로 다른 서비스와의 비동기 통신 지원

* **Chores**
  * Docker 컨테이너화 및 Docker Compose 구성 추가
  * PostgreSQL 데이터베이스 지원 및 Kafka 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->