### PR TITLE
refactor : 컨트롤러 및 서비스 응답 통일화

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationApplyCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationApplyCommand.java
@@ -1,0 +1,13 @@
+package org.pgsg.reservation.application.dto.command;
+
+import java.util.UUID;
+
+public record ReservationApplyCommand(
+        UUID reservationId,
+        UUID userId,
+        String nickname
+) {
+    public static ReservationApplyCommand of(UUID reservationId, UUID userId, String nickname) {
+        return new ReservationApplyCommand(reservationId, userId, nickname);
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationConfirmCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationConfirmCommand.java
@@ -1,0 +1,13 @@
+package org.pgsg.reservation.application.dto.command;
+
+import java.util.UUID;
+
+public record ReservationConfirmCommand(
+    UUID reservationId,
+    UUID userId,
+    String role
+){
+    public static ReservationConfirmCommand of(UUID reservationId, UUID userId, String role) {
+        return new ReservationConfirmCommand(reservationId,userId,role);
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
@@ -1,19 +1,38 @@
 package org.pgsg.reservation.application.dto.command;
 
-import lombok.Builder;
-import lombok.Getter;
+import org.pgsg.reservation.infrastructure.listener.dto.TimeDealProductEvent;
+import org.pgsg.reservation.presentation.dto.request.ReservationCreateRequest;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Getter
-@Builder
-public class ReservationCreateCommand {
-    private UUID productId;
+public record ReservationCreateCommand (
+        UUID productId,
+        UUID sellerId,
+        String sellerName,
+        String productName,
+        Integer price,
+        LocalDateTime endTime
+){
+        public static ReservationCreateCommand of(ReservationCreateRequest request) {
+            return new ReservationCreateCommand(
+                    request.getProductId(),
+                    request.getSellerId(),
+                    request.getSellerNickname(), // 명칭 매핑 (Nickname -> Name)
+                    request.getProductName(),
+                    request.getPrice(),
+                    request.getEndTime()
+            );
+        }
 
-    private UUID sellerId;      // 판매자 ID
-    private String sellerName;  // 판매자 이름 (또는 닉네임)
-    private String productName; // 상품명
-    private Integer price;      // 가격
-    private LocalDateTime endTime; // 종료 시간
-}
+    public static ReservationCreateCommand from(TimeDealProductEvent event) {
+        return new ReservationCreateCommand(
+                event.productId(),
+                event.sellerId(),
+                event.sellerName(),
+                event.name(),
+                event.price(),
+                event.endTime()
+        );
+    }
+    }

--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationCreateCommand.java
@@ -1,8 +1,5 @@
 package org.pgsg.reservation.application.dto.command;
 
-import org.pgsg.reservation.infrastructure.listener.dto.TimeDealProductEvent;
-import org.pgsg.reservation.presentation.dto.request.ReservationCreateRequest;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -14,25 +11,4 @@ public record ReservationCreateCommand (
         Integer price,
         LocalDateTime endTime
 ){
-        public static ReservationCreateCommand of(ReservationCreateRequest request) {
-            return new ReservationCreateCommand(
-                    request.getProductId(),
-                    request.getSellerId(),
-                    request.getSellerNickname(), // 명칭 매핑 (Nickname -> Name)
-                    request.getProductName(),
-                    request.getPrice(),
-                    request.getEndTime()
-            );
-        }
-
-    public static ReservationCreateCommand from(TimeDealProductEvent event) {
-        return new ReservationCreateCommand(
-                event.productId(),
-                event.sellerId(),
-                event.sellerName(),
-                event.name(),
-                event.price(),
-                event.endTime()
-        );
-    }
-    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/command/ReservationExpireCommand.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/command/ReservationExpireCommand.java
@@ -1,0 +1,24 @@
+package org.pgsg.reservation.application.dto.command;
+
+import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
+import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
+
+import java.util.UUID;
+
+public record ReservationExpireCommand(
+        UUID reservationId,
+        UUID userId,
+        String role,
+        ReservationStatus targetStatus,
+        String reason
+) {
+    public static ReservationExpireCommand of(UUID reservationId, UUID userId, String role, ReservationAdminCancelRequest request) {
+        return new ReservationExpireCommand(
+                reservationId,
+                userId,
+                role,
+                request.targetStatus(),
+                request.reason()
+        );
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/info/ReservationCandidateInfo.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/info/ReservationCandidateInfo.java
@@ -1,0 +1,23 @@
+package org.pgsg.reservation.application.dto.info;
+
+import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReservationCandidateInfo(
+        Long id,
+        UUID candidateId,
+        String candidateNickname,
+        String status,
+        LocalDateTime createdAt
+) {
+    public static ReservationCandidateInfo from(ReservationCandidate candidate) {
+        return new ReservationCandidateInfo(
+                candidate.getId(),
+                candidate.getCandidateId(),
+                candidate.getCandidateNickname(),
+                candidate.getStatus().name(),
+                candidate.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/dto/info/ReservationStateInfo.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/info/ReservationStateInfo.java
@@ -7,13 +7,13 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
-public record ReservationCancelInfo(
+public record ReservationStateInfo(
         UUID reservationId,
         ReservationStatus status,
         LocalDateTime updatedAt
 ) {
-    public static ReservationCancelInfo from(Reservation reservation) {
-        return ReservationCancelInfo.builder()
+    public static ReservationStateInfo from(Reservation reservation) {
+        return ReservationStateInfo.builder()
                 .reservationId(reservation.getId())
                 .status(reservation.getStatus())
                 .updatedAt(reservation.getModifiedAt())

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -177,7 +177,7 @@ public class ReservationService {
         if (history != null) {
             reservationHistoryRepository.save(history);
         } else {
-            log.info("이미 결제 완료 처리된 예약입니다(중복 요청 무시): reservationId={}", reservation);
+            log.info("이미 결제 완료 처리된 예약입니다(중복 요청 무시): reservationId={}", reservation.getId());
         }
 
         return ReservationStateInfo.from(reservation);

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -2,11 +2,10 @@ package org.pgsg.reservation.application.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
-import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
+import org.pgsg.reservation.application.dto.command.*;
 import org.pgsg.reservation.application.dto.result.ReservationDetailResult;
 import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublisher;
-import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
+import org.pgsg.reservation.application.dto.info.ReservationStateInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.dto.result.ReservationSearchResult;
@@ -19,8 +18,7 @@ import org.pgsg.reservation.domain.model.reservationhistory.ReservationHistory;
 import org.pgsg.reservation.domain.repository.ReservationHistoryRepository;
 import org.pgsg.reservation.domain.service.ReservationDomainService;
 import org.pgsg.reservation.domain.repository.ReservationRepository;
-import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
-import org.pgsg.reservation.presentation.dto.response.ReservationCandidateResponse;
+import org.pgsg.reservation.application.dto.info.ReservationCandidateInfo;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,16 +41,16 @@ public class ReservationService {
     @Transactional
     public ReservationCreateResult createReservation(ReservationCreateCommand command) {
         try {
-            if (reservationRepository.existsByProductId(command.getProductId())) {
+            if (reservationRepository.existsByProductId(command.productId())) {
                 throw new ReservationException(ReservationErrorCode.ALREADY_EXISTS);
             }
 
-            SellerInfo seller = SellerInfo.of(command.getSellerId(), "test");
+            SellerInfo seller = SellerInfo.of(command.sellerId(), "test");
             ProductInfo product = ProductInfo.of(
-                    command.getProductId(),
-                    command.getPrice(),
-                    command.getProductName(),
-                    command.getEndTime()
+                    command.productId(),
+                    command.price(),
+                    command.productName(),
+                    command.endTime()
             );
 
             Reservation reservation = reservationDomainService.createReservation(
@@ -119,15 +117,15 @@ public class ReservationService {
 
     // 예약 신청
     @Transactional
-    public ReservationCandidateResponse applyReservation(UUID reservationId, UUID userId, String nickname) {
+    public ReservationCandidateInfo applyReservation(ReservationApplyCommand command) {
         Reservation savedReservation;
 
         // 예약 엔티티 조회
-        Reservation reservation = reservationRepository.findById(reservationId)
+        Reservation reservation = reservationRepository.findById(command.reservationId())
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
         // 도메인 서비스를 통한 신청 로직 (후보자 생성 및 추가)
-        ReservationCandidate candidate = reservationDomainService.addCandidate(reservation, userId, nickname);
+        ReservationCandidate candidate = reservationDomainService.addCandidate(reservation, command.userId(), command.nickname());
 
         // 변경사항 저장과 예외 감시
         try {
@@ -141,16 +139,16 @@ public class ReservationService {
 
         // 방금 저장된 예약에서 추하한 후보자 찾기
         ReservationCandidate savedCandidate = savedReservation.getCandidates().stream()
-                .filter(c -> c.getCandidateId().equals(userId))
+                .filter(c -> c.getCandidateId().equals(command.userId()))
                 .findFirst()
                 .orElse(candidate);
 
-        return ReservationCandidateResponse.from(savedCandidate);
+        return ReservationCandidateInfo.from(savedCandidate);
     }
 
     // 구매자 취소 처리 로직
     @Transactional
-    public ReservationCancelInfo cancelByBuyer(ReservationCancelCommand command) {
+    public ReservationStateInfo cancelByBuyer(ReservationCancelCommand command) {
         Reservation reservation = findById(command.reservationId());
 
         ReservationHistory history = reservationDomainService.cancelByBuyer(
@@ -162,32 +160,32 @@ public class ReservationService {
 
         reservationHistoryRepository.save(history);
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     // 추후 결제 시스템 연동시 트리거 발동
     @Transactional
-    public ReservationCancelInfo confirmPayment(UUID reservationId, UUID userId, String role) {
-        Reservation reservation = findById(reservationId);
+    public ReservationStateInfo confirmPayment(ReservationConfirmCommand command) {
+        Reservation reservation = findById(command.reservationId());
 
         ReservationHistory history = reservationDomainService.confirmPayment(
                 reservation,
-                userId,
-                role
+                command.userId(),
+                command.role()
         );
 
         if (history != null) {
             reservationHistoryRepository.save(history);
         } else {
-            log.info("이미 결제 완료 처리된 예약입니다(중복 요청 무시): reservationId={}", reservationId);
+            log.info("이미 결제 완료 처리된 예약입니다(중복 요청 무시): reservationId={}", reservation);
         }
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     // 판매자 취소 로직
     @Transactional
-    public ReservationCancelInfo cancelBySeller(ReservationCancelCommand command) {
+    public ReservationStateInfo cancelBySeller(ReservationCancelCommand command) {
         Reservation reservation = findById(command.reservationId());
 
         ReservationHistory history = reservationDomainService.cancelBySeller(
@@ -199,57 +197,51 @@ public class ReservationService {
 
         reservationHistoryRepository.save(history);
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     // 예약 만료
     @Transactional
-    public ReservationCancelInfo expireByAdmin(
-            UUID reservationId,
-            ReservationAdminCancelRequest request,
-            UUID adminId,
-            String role
-    ) {
-        Reservation reservation = findById(reservationId);
+    public ReservationStateInfo expireByAdmin(ReservationExpireCommand command) {
+        Reservation reservation = findById(command.reservationId());
 
         ReservationHistory history = reservationDomainService.expireByAdmin(
                 reservation,
-                adminId,
-                role,
-                request.targetStatus(),
-                request.reason()
+                command.userId(),
+                command.role(),
+                command.targetStatus(),
+                command.reason()
         );
 
         reservationHistoryRepository.save(history);
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     // 예약 완료
     @Transactional
-    public ReservationCancelInfo completeReservation(UUID reservationId, UUID userId, String role) {
+    public ReservationStateInfo completeReservation(ReservationConfirmCommand command) {
         // 예약 엔티티 조회
-        Reservation reservation = findById(reservationId);
+        Reservation reservation = findById(command.reservationId());
 
-        ReservationHistory history = reservationDomainService.completeReservation(reservation,userId,role);
+        ReservationHistory history = reservationDomainService.completeReservation(reservation,command.userId(),command.role());
 
         reservationHistoryRepository.save(history);
-
         reservationEventPublisher.publishReservationCompleted(reservation);
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     // 거래 완료
     @Transactional
-    public ReservationCancelInfo confirmTrade(UUID reservationId) {
+    public ReservationStateInfo confirmTrade(UUID reservationId) {
 
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
         reservation.close();
 
-        return ReservationCancelInfo.from(reservation);
+        return ReservationStateInfo.from(reservation);
     }
 
     /**

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -234,10 +234,9 @@ public class ReservationService {
 
     // 거래 완료
     @Transactional
-    public ReservationStateInfo confirmTrade(UUID reservationId) {
+    public ReservationStateInfo confirmTrade(ReservationConfirmCommand command) {
 
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+        Reservation reservation = findById(command.reservationId());
 
         reservation.close();
 

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -34,14 +34,7 @@ public class ProductListener {
             log.info("타임딜 상품 생성 이벤트 수신 - Product ID: {}, Name: {}",
                     event.productId(), event.name());
 
-            ReservationCreateCommand command = ReservationCreateCommand.builder()
-                    .productId(event.productId())
-                    .productName(event.name())
-                    .price(event.price())
-                    .endTime(event.endTime())
-                    .sellerId(event.sellerId())
-                    .sellerName(event.sellerName())
-                    .build();
+            ReservationCreateCommand command = ReservationCreateCommand.from(event);
 
             reservationService.createReservation(command);
         }catch (ReservationException e) {

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -34,7 +34,10 @@ public class ProductListener {
             log.info("타임딜 상품 생성 이벤트 수신 - Product ID: {}, Name: {}",
                     event.productId(), event.name());
 
-            ReservationCreateCommand command = ReservationCreateCommand.from(event);
+            ReservationCreateCommand command = new ReservationCreateCommand(
+                    event.productId(), event.sellerId(), event.sellerName(),
+                    event.name(), event.price(), event.endTime()
+            );
 
             reservationService.createReservation(command);
         }catch (ReservationException e) {

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
@@ -5,10 +5,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.pgsg.common.messaging.annotation.IdempotentConsumer;
+import org.pgsg.reservation.application.dto.command.ReservationConfirmCommand;
 import org.pgsg.reservation.application.service.ReservationService;
 import org.pgsg.reservation.infrastructure.listener.dto.TradeCompletedEvent;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 
 @Slf4j
@@ -18,6 +21,9 @@ public class ReservationEventListener {
 
     private final ReservationService reservationService;
     private final ObjectMapper objectMapper;
+
+    private static final UUID SYSTEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static final String SYSTEM_ROLE = "ADMIN";
 
     /**
      * 거래 서비스로부터 거래 완료 이벤트를 수신
@@ -33,9 +39,14 @@ public class ReservationEventListener {
             TradeCompletedEvent event = objectMapper.readValue(record.value(), TradeCompletedEvent.class);
             log.info("거래 완료 이벤트 수신 - Trade ID: {}, Reservation ID: {}",
                     event.tradeId(), event.reservationId());
-            reservationService.confirmTrade(
-                    event.reservationId()
+
+            ReservationConfirmCommand command = new ReservationConfirmCommand(
+                    event.reservationId(),
+                    SYSTEM_ID,
+                    SYSTEM_ROLE
             );
+
+            reservationService.confirmTrade(command);
 
             log.info("예약 확정 처리 성공 - Reservation ID: {}", event.reservationId());
         }catch (Exception e) {

--- a/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/scheduler/ReservationExpiryScheduler.java
@@ -2,11 +2,11 @@ package org.pgsg.reservation.infrastructure.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.pgsg.reservation.application.dto.command.ReservationExpireCommand;
 import org.pgsg.reservation.application.service.ReservationService;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 import org.pgsg.reservation.domain.repository.ReservationRepository;
-import org.pgsg.reservation.presentation.dto.request.ReservationAdminCancelRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +22,7 @@ public class ReservationExpiryScheduler {
     private final ReservationService reservationService;
     private final ReservationRepository reservationRepository;
 
-    // 시스템 자동 처리를 위한 가상의 관리자 ID (추후 시스템 관리자 용 id 따로 추가)
+    // 시스템 자동 처리를 위한 가상의 관리자 정보
     private static final UUID SYSTEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     private static final String SYSTEM_ROLE = "ADMIN";
 
@@ -34,6 +34,7 @@ public class ReservationExpiryScheduler {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(60);
         List<ReservationStatus> targetStatuses = List.of(ReservationStatus.PENDING, ReservationStatus.PAID);
 
+        // 1시간 동안 상태 변화가 없는 예약들 조회
         List<Reservation> expiredReservations = reservationRepository.findAllByStatusInAndModifiedAtBefore(
                 targetStatuses,
                 threshold
@@ -45,15 +46,10 @@ public class ReservationExpiryScheduler {
 
         for (Reservation reservation : expiredReservations) {
             try {
-                // 현재 예약 상태에 맞는 요청 객체를 생성
-                ReservationAdminCancelRequest request = createCancelRequest(reservation);
+                ReservationExpireCommand command = createExpireCommand(reservation);
+                reservationService.expireByAdmin(command);
 
-                reservationService.expireByAdmin(
-                        reservation.getId(),
-                        request,
-                        SYSTEM_ID,
-                        SYSTEM_ROLE
-                );
+                log.info("예약 자동 만료 완료 (ID: {}, 상태: {})", reservation.getId(), reservation.getStatus());
             } catch (Exception e) {
                 log.error("예약 자동 만료 처리 중 오류 발생 (ID: {}): {}", reservation.getId(), e.getMessage());
             }
@@ -63,23 +59,26 @@ public class ReservationExpiryScheduler {
     /**
      * 예약 상태에 따른 적절한 취소 요청 객체를 생성하는 메서드
      */
-    private ReservationAdminCancelRequest createCancelRequest(Reservation reservation) {
+    private ReservationExpireCommand createExpireCommand(Reservation reservation) {
+        ReservationStatus targetStatus;
+        String reason;
 
-        //
         if (reservation.getStatus() == ReservationStatus.PENDING) {
-            return new ReservationAdminCancelRequest(
-                    ReservationStatus.CANCELLED_BY_BUYER,
-                    "결제 제한 시간(1시간) 초과로 인한 자동 취소"
-            );
+            targetStatus = ReservationStatus.CANCELLED_BY_BUYER;
+            reason = "결제 제한 시간(1시간) 초과로 인한 자동 취소";
+        } else if (reservation.getStatus() == ReservationStatus.PAID) {
+            targetStatus = ReservationStatus.CANCELLED_BY_SELLER;
+            reason = "채팅 수락 제한 시간(1시간) 초과로 인한 자동 취소";
+        } else {
+            throw new IllegalStateException("자동 만료 대상이 아닌 상태입니다: " + reservation.getStatus());
         }
 
-        // PAID 상태일 때
-        if (reservation.getStatus() == ReservationStatus.PAID) {
-            return new ReservationAdminCancelRequest(
-                    ReservationStatus.CANCELLED_BY_SELLER,
-                    "채팅 수락 제한 시간(1시간) 초과로 인한 자동 취소"
-            );
-        }
-        throw new IllegalStateException("자동 만료 대상이 아닌 상태입니다: " + reservation.getStatus());
+        return new ReservationExpireCommand(
+                reservation.getId(),
+                SYSTEM_ID,
+                SYSTEM_ROLE,
+                targetStatus,
+                reason
+        );
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -47,7 +47,7 @@ public class ReservationController {
     @GetMapping
     public ReservationPageResponse<ReservationResponse> getReservations(
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role,
+            @RequestHeader("X-User-Roles") String role,
             @ModelAttribute ReservationSearchRequest request,
             @PageableDefault(size = 10) Pageable pageable
     ) {
@@ -71,7 +71,7 @@ public class ReservationController {
     public ReservationDetailResponse getReservationDetail(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationDetailResult result = reservationService.getReservationDetail(reservationId, userId, role);
 
@@ -98,7 +98,7 @@ public class ReservationController {
             @PathVariable UUID reservationId,
             @RequestBody ReservationCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationCancelCommand command = ReservationCancelCommand.of(
                 reservationId,
@@ -117,7 +117,7 @@ public class ReservationController {
     public ReservationStateResponse confirmPayment(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationConfirmCommand command = ReservationConfirmCommand.of(
                 reservationId,
@@ -136,7 +136,7 @@ public class ReservationController {
             @PathVariable UUID reservationId,
             @RequestBody ReservationCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationCancelCommand command = ReservationCancelCommand.of(
                 reservationId,
@@ -156,7 +156,7 @@ public class ReservationController {
             @PathVariable UUID reservationId,
             @RequestBody ReservationAdminCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationExpireCommand command = ReservationExpireCommand.of(
                 reservationId,
@@ -179,7 +179,7 @@ public class ReservationController {
     public ReservationStateResponse completeReservation(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
 
          ReservationConfirmCommand command = ReservationConfirmCommand.of(
@@ -198,7 +198,7 @@ public class ReservationController {
     public ReservationStateResponse confirmTrade(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestHeader("X-User-Role") String role
+            @RequestHeader("X-User-Roles") String role
     ) {
         ReservationConfirmCommand command = ReservationConfirmCommand.of(
                 reservationId,

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -2,9 +2,9 @@ package org.pgsg.reservation.presentation.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.pgsg.reservation.application.dto.command.ReservationCancelCommand;
-import org.pgsg.reservation.application.dto.command.ReservationCreateCommand;
-import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
+import org.pgsg.reservation.application.dto.command.*;
+import org.pgsg.reservation.application.dto.info.ReservationCandidateInfo;
+import org.pgsg.reservation.application.dto.info.ReservationStateInfo;
 import org.pgsg.reservation.application.dto.query.ReservationSearchQuery;
 import org.pgsg.reservation.application.dto.result.ReservationCreateResult;
 import org.pgsg.reservation.application.dto.result.ReservationDetailResult;
@@ -33,14 +33,7 @@ public class ReservationController {
     public ReservationResponse createReservation(
             @Valid @RequestBody ReservationCreateRequest request
     ) {
-        ReservationCreateCommand command = ReservationCreateCommand.builder()
-                .productId(request.getProductId())
-                .productName(request.getProductName())
-                .price(request.getPrice())
-                .endTime(request.getEndTime())
-                .sellerId(request.getSellerId())
-                .sellerName(request.getSellerNickname())
-                .build();
+        ReservationCreateCommand command = ReservationCreateCommand.of(request);
 
         ReservationCreateResult result = reservationService.createReservation(command);
 
@@ -77,25 +70,28 @@ public class ReservationController {
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-
         ReservationDetailResult result = reservationService.getReservationDetail(reservationId, userId, role);
 
         return ReservationDetailResponse.from(result);
     }
 
     // 예약 신청
-    @PostMapping("/{reservationId}")
+    @PatchMapping("/{reservationId}")
     public ReservationCandidateResponse applyReservation(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Nickname") String nickname
     ) {
-        return reservationService.applyReservation(reservationId, userId, nickname);
+        ReservationApplyCommand command = ReservationApplyCommand.of(reservationId, userId, nickname);
+
+        ReservationCandidateInfo info = reservationService.applyReservation(command);
+
+        return ReservationCandidateResponse.of(info, "예약 신청이 성공적으로 완료되었습니다.");
     }
 
     // 구매자 사유 취소 (구매자/관리자)
     @PatchMapping("/{reservationId}/cancel/buyer")
-    public ReservationCancelResponse cancelByBuyer(
+    public ReservationStateResponse cancelByBuyer(
             @PathVariable UUID reservationId,
             @RequestBody ReservationCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
@@ -108,28 +104,32 @@ public class ReservationController {
                 request.reason()
         );
 
-        ReservationCancelInfo info = reservationService.cancelByBuyer(command);
+        ReservationStateInfo info = reservationService.cancelByBuyer(command);
 
-        return ReservationCancelResponse.of(info, "구매자 사유 취소가 완료되었습니다.");
+        return ReservationStateResponse.of(info, "구매자 사유 취소가 완료되었습니다.");
     }
 
     // 결제 완료
     @PatchMapping("/{reservationId}/paymentconfirm")
-    public ReservationCancelInfo confirmPayment(
+    public ReservationStateResponse confirmPayment(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        return reservationService.confirmPayment(
+        ReservationConfirmCommand command = ReservationConfirmCommand.of(
                 reservationId,
                 userId,
                 role
         );
+
+        ReservationStateInfo info = reservationService.confirmPayment(command);
+
+        return ReservationStateResponse.of(info, "구매자의 결제 완료에 따라 예약 완료 처리가 완료되었습니다.");
     }
 
     // 판매자 사유로 인한 취소(판매자,관리자)
     @PatchMapping("/{reservationId}/cancel/seller")
-    public ReservationCancelResponse cancelBySeller(
+    public ReservationStateResponse cancelBySeller(
             @PathVariable UUID reservationId,
             @RequestBody ReservationCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
@@ -142,60 +142,63 @@ public class ReservationController {
                 request.reason()
         );
 
-        ReservationCancelInfo info = reservationService.cancelBySeller(command);
+        ReservationStateInfo info = reservationService.cancelBySeller(command);
 
-        return ReservationCancelResponse.of(info, "판매자 사유 취소가 완료되었습니다.");
+        return ReservationStateResponse.of(info, "판매자 사유 취소가 완료되었습니다.");
     }
 
     // 예약 만료(관리자만 조정 가능)
     @PatchMapping("/{reservationId}/expire")
-    public ReservationCancelResponse expireByAdmin(
+    public ReservationStateResponse expireByAdmin(
             @PathVariable UUID reservationId,
             @RequestBody ReservationAdminCancelRequest request,
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        ReservationCancelInfo info = reservationService.expireByAdmin(
+        ReservationExpireCommand command = ReservationExpireCommand.of(
                 reservationId,
-                request,
                 userId,
-                role
+                role,
+                request
         );
+
+        ReservationStateInfo info = reservationService.expireByAdmin(command);
 
         String message = (request.targetStatus() == ReservationStatus.CANCELLED_BY_BUYER)
                 ? "관리자 권한으로 구매자 사유 취소(승계) 처리가 완료되었습니다."
                 : "관리자 권한으로 판매자 사유 취소(종료) 처리가 완료되었습니다.";
 
-        return ReservationCancelResponse.of(info, message);
+        return ReservationStateResponse.of(info, message);
     }
 
     // 예약 완료
     @PatchMapping("/{reservationId}/complete")
-    public ReservationCancelResponse completeReservation(
+    public ReservationStateResponse completeReservation(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        ReservationCancelInfo info = reservationService.completeReservation(
-                reservationId,
-                userId,
-                role
-        );
 
-        return ReservationCancelResponse.of(info, "판매자 채팅 수락에 따라 예약 완료 처리가 완료되었습니다.");
+         ReservationConfirmCommand command = ReservationConfirmCommand.of(
+                 reservationId,
+                 userId,
+                 role
+         );
+
+        ReservationStateInfo info = reservationService.completeReservation(command);
+
+        return ReservationStateResponse.of(info, "판매자 채팅 수락에 따라 예약 완료 처리가 완료되었습니다.");
     }
 
     // 거래 완료
     @PatchMapping("/{reservationId}/tradeconfirm")
-    public ReservationCancelResponse confirmTrade(
+    public ReservationStateResponse confirmTrade(
             @PathVariable UUID reservationId,
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        ReservationCancelInfo info = reservationService.confirmTrade(
-                reservationId
-        );
+        ReservationStateInfo info = reservationService.confirmTrade(reservationId);
 
-        return ReservationCancelResponse.of(info, "거래가 성공적으로 완료되어 확정 처리되었습니다.");
+        return ReservationStateResponse.of(info, "거래가 성공적으로 완료되어 확정 처리되었습니다.");
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -200,7 +200,13 @@ public class ReservationController {
             @RequestHeader("X-User-Id") UUID userId,
             @RequestHeader("X-User-Role") String role
     ) {
-        ReservationStateInfo info = reservationService.confirmTrade(reservationId);
+        ReservationConfirmCommand command = ReservationConfirmCommand.of(
+                reservationId,
+                userId,
+                role
+        );
+
+        ReservationStateInfo info = reservationService.confirmTrade(command);
 
         return ReservationStateResponse.of(info, "거래가 성공적으로 완료되어 확정 처리되었습니다.");
     }

--- a/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
+++ b/src/main/java/org/pgsg/reservation/presentation/controller/ReservationController.java
@@ -33,7 +33,10 @@ public class ReservationController {
     public ReservationResponse createReservation(
             @Valid @RequestBody ReservationCreateRequest request
     ) {
-        ReservationCreateCommand command = ReservationCreateCommand.of(request);
+        ReservationCreateCommand command = new ReservationCreateCommand(
+                request.getProductId(), request.getSellerId(), request.getSellerNickname(),
+                request.getProductName(), request.getPrice(), request.getEndTime()
+        );
 
         ReservationCreateResult result = reservationService.createReservation(command);
 

--- a/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCandidateResponse.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationCandidateResponse.java
@@ -1,23 +1,12 @@
 package org.pgsg.reservation.presentation.dto.response;
 
-import org.pgsg.reservation.domain.model.reservationcandidate.ReservationCandidate;
-import java.time.LocalDateTime;
-import java.util.UUID;
+import org.pgsg.reservation.application.dto.info.ReservationCandidateInfo;
 
 public record ReservationCandidateResponse(
-        Long id,                        // 예약후보 고유 순번
-        UUID candidateId,              // 예약후보자 회원 ID
-        String candidateNickname,      // 예약후보자 닉네임
-        String status,                 // 선정 상태 (WAITING, SELECTED, CANCELLED)
-        LocalDateTime createdAt        // 예약후보 등록 일자
+        ReservationCandidateInfo info,
+        String message
 ) {
-    public static ReservationCandidateResponse from(ReservationCandidate candidate) {
-        return new ReservationCandidateResponse(
-                candidate.getId(),               // 엔티티의 id 필드 매핑
-                candidate.getCandidateId(),       // 후보자 UUID 매핑
-                candidate.getCandidateNickname(), // 후보자 닉네임 매핑
-                candidate.getStatus().name(),     // Enum을 String으로 변환
-                candidate.getCreatedAt()          // BaseEntity로부터 상속받은 생성일자
-        );
+    public static ReservationCandidateResponse of(ReservationCandidateInfo info, String message) {
+        return new ReservationCandidateResponse(info, message);
     }
 }

--- a/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationStateResponse.java
+++ b/src/main/java/org/pgsg/reservation/presentation/dto/response/ReservationStateResponse.java
@@ -1,21 +1,21 @@
 package org.pgsg.reservation.presentation.dto.response;
 
 import lombok.Builder;
-import org.pgsg.reservation.application.dto.info.ReservationCancelInfo;
+import org.pgsg.reservation.application.dto.info.ReservationStateInfo;
 import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
-public record ReservationCancelResponse(
+public record ReservationStateResponse(
         UUID reservationId,
         ReservationStatus status,
         LocalDateTime updatedAt,
         String message
 ) {
-    public static ReservationCancelResponse of(ReservationCancelInfo info, String message) {
-        return ReservationCancelResponse.builder()
+    public static ReservationStateResponse of(ReservationStateInfo info, String message) {
+        return ReservationStateResponse.builder()
                 .reservationId(info.reservationId())
                 .status(info.status())
                 .updatedAt(info.updatedAt())


### PR DESCRIPTION
### 작업 배경
- 컨트롤러 및 서비스 부분 응답이 각기 달라 이를 통일화 시켰습니다

### 작업 내용
- application dto에 command 부분 및 info 부분 추가
- 컨트롤러 및 서비스 응답 부분 통일화

### 테스트 여부
- docker-compose up -d --build 테스트 통과

### 기타
- 데이터가 제대로 이동하는지는 추후 테스트 예정입니다

### 이슈
> This closes #37 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 완료 시 이벤트 발행 추가

* **개선 사항**
  * 예약 API 응답 및 DTO 표준화(상태 응답 통합)
  * 예약 생성·신청 흐름 개선(명시적 명령 객체 사용)
  * 만료 스케줄러·이벤트 리스너에서 명령 기반 처리로 변경
  * 요청 헤더명 X-User-Role → X-User-Roles로 변경
  * 예약 후보 응답 구조 단순화

* **버그 수정**
  * 중복 예약 검증 및 예외 처리 개선 (중복 처리 대응, idempotency)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->