### PR TITLE
Feat : 판매자 사유로 취소 상품에 이벤트 발송

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/dto/event/ReservationCancelledEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/ReservationCancelledEvent.java
@@ -1,0 +1,19 @@
+package org.pgsg.reservation.application.dto.event;
+
+import org.pgsg.reservation.domain.model.reservation.Reservation;
+
+import java.util.UUID;
+
+public record ReservationCancelledEvent(
+        UUID reservationId,
+        UUID productId,
+        String reason
+) {
+    public static ReservationCancelledEvent from(Reservation reservation, String reason) {
+        return new ReservationCancelledEvent(
+                reservation.getId(),
+                reservation.getProductInfo().getProductId(),
+                reason
+        );
+    }
+}

--- a/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
+++ b/src/main/java/org/pgsg/reservation/application/service/ReservationService.java
@@ -222,6 +222,7 @@ public class ReservationService {
         );
 
         reservationHistoryRepository.save(history);
+        reservationEventPublisher.publishReservationCancelled(reservation,command.reason());
 
         return ReservationStateInfo.from(reservation);
     }

--- a/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservation/Reservation.java
@@ -90,12 +90,6 @@ public class Reservation extends BaseEntity {
         this.status = ReservationStatus.COMPLETED;
     }
 
-    // 최종 종료: 완료된 거래를 아카이브 상태로 변경
-    public void close() {
-        validateStatus(ReservationStatus.COMPLETED);
-        this.status = ReservationStatus.CLOSED;
-    }
-
     // 거래 복구: COMPLETED 상태에서 취소 발생 시 AVAILABLE로 복구
     public void rollbackToAvailable() {
         validateStatus(ReservationStatus.COMPLETED);
@@ -117,9 +111,9 @@ public class Reservation extends BaseEntity {
         this.buyerInfo = null; // 기존 구매자 정보 제거
     }
 
-    // 판매자 취소: PENDING 또는 PAID 상태에서 판매자가 취소(영구 종료)
+    // 판매자 취소: AVAILABLE,PENDING,PAID 상태에서 판매자가 취소(영구 종료)
     public void cancelBySeller() {
-        validateStatus(ReservationStatus.PENDING, ReservationStatus.PAID);
+        validateStatus(ReservationStatus.AVAILABLE,ReservationStatus.PENDING, ReservationStatus.PAID);
         this.status = ReservationStatus.CANCELLED_BY_SELLER;
     }
 

--- a/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
+++ b/src/main/java/org/pgsg/reservation/domain/model/reservationhistory/ReservationHistory.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.pgsg.common.domain.BaseEntity;
 import org.pgsg.reservation.domain.model.reservation.ReservationStatus;
 
 import java.util.UUID;
@@ -14,7 +15,7 @@ import java.util.UUID;
 @Table(name = "p_reservation_histories")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ReservationHistory {
+public class ReservationHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -21,7 +21,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
     @Value("${topics.reservation.completed}")
     private String completedTopicName;
 
-    @Value("prod-reservation-buyercancelled")
+    @Value("${topics.reservation.cancelled}")
     private String buyerCancelledTopicName;
 
     @Override

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pgsg.common.event.Events;
 import org.pgsg.common.event.OutboxEvent;
+import org.pgsg.reservation.application.dto.event.ReservationCancelledEvent;
 import org.pgsg.reservation.application.dto.event.ReservationCompletedEvent;
 import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublisher;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
@@ -18,7 +19,10 @@ import java.util.UUID;
 public class ReservationEventBridge implements ReservationEventPublisher {
 
     @Value("${topics.reservation.completed}")
-    private String topicName;
+    private String completedTopicName;
+
+    @Value("prod-reservation-buyercancelled")
+    private String buyerCancelledTopicName;
 
     @Override
     public void publishReservationCompleted(Reservation reservation) {
@@ -38,7 +42,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
                     correlationId,    // 1. correlationId
                     domainId,         // 2. domainId (UUID 타입)
                     "RESERVATION",    // 3. domainType
-                    topicName,        // 4. eventType (토픽명)
+                    completedTopicName,        // 4. eventType (토픽명)
                     event             // 5. payload
             ));
 
@@ -47,6 +51,35 @@ public class ReservationEventBridge implements ReservationEventPublisher {
         } catch (Exception e) {
             log.error("Outbox 등록 실패 - 예약 ID: {}", reservation.getId(), e);
             throw new RuntimeException("이벤트 발행 중 오류 발생", e);
+        }
+    }
+
+    @Override
+    public void publishReservationCancelled(Reservation reservation, String reason) {
+        try {
+            log.info("판매자 사유로 인한 취소 Outbox 등록 시작 - 예약 ID: {}", reservation.getId());
+
+            // Product/Trade 서비스에서 식별자로 쓸 ID (상품 ID)
+            UUID correlationId = UUID.fromString(reservation.getProductInfo().getProductId().toString());
+
+            // Outbox 테이블의 PK로 저장될 ID (예약 ID)
+            UUID domainId = UUID.fromString(reservation.getId().toString());
+
+            ReservationCancelledEvent event = ReservationCancelledEvent.from(reservation, reason);
+
+            Events.trigger(new OutboxEvent(
+                    correlationId,    // 연관 ID (상품 ID)
+                    domainId,         // 도메인 ID (예약 ID)
+                    "RESERVATION",    // 도메인 타입
+                    buyerCancelledTopicName,   // 이벤트 타입 (취소 토픽명)
+                    event             // 페이로드
+            ));
+
+            log.info("판매자 사유로 인한 취소 Outbox 등록 완료 - correlationId: {}", correlationId);
+
+        } catch (Exception e) {
+            log.error("취소 Outbox 등록 실패 - 예약 ID: {}", reservation.getId(), e);
+            throw new RuntimeException("취소 이벤트 발행 중 오류 발생", e);
         }
     }
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/ReservationEventPublisher.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/dto/ReservationEventPublisher.java
@@ -4,4 +4,6 @@ import org.pgsg.reservation.domain.model.reservation.Reservation;
 
 public interface ReservationEventPublisher {
     void publishReservationCompleted(Reservation reservation);
+
+    void publishReservationCancelled(Reservation reservation, String reason);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,5 +70,6 @@ eureka:
 topics:
   reservation:
     completed: prod-reservation-completed
+    cancelled: prod-reservation-cancelled
   product:
     created: prod-product-created


### PR DESCRIPTION
### 작업 배경
- 판매자 사유로 예약 취소 시 자동으로 상품에 취소하도록 이벤트 발송

### 작업 내용
- ReservationCancelledEvent dto 작성
- 판매자로 인한 거래 취소 시 이벤트 발송 코드 작성

### 테스트 여부
- 데이터 수정 완료 확인하였습니다

### 이슈
>  This closes #42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 취소 이벤트 발행 메커니즘 추가로 취소 시 사유를 포함하여 발행 가능

* **개선 사항**
  * 판매자가 AVAILABLE 상태에서도 예약 취소 가능하도록 확대 (기존: PENDING, PAID 상태만 가능)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/reservation-service/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->