### PR TITLE
Feat/40 reservation eventfailreturn

### DIFF
--- a/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
@@ -1,0 +1,8 @@
+package org.pgsg.reservation.application.dto.event;
+
+import java.util.UUID;
+
+public record ReservationFailedEvent(
+        UUID productId,
+        String reason
+) {}

--- a/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
@@ -3,6 +3,6 @@ package org.pgsg.reservation.application.dto.event;
 import java.util.UUID;
 
 public record ReservationFailedEvent(
-        UUID Id,
+        UUID id,
         String reason
 ) {}

--- a/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
+++ b/src/main/java/org/pgsg/reservation/application/dto/event/ReservationFailedEvent.java
@@ -3,6 +3,6 @@ package org.pgsg.reservation.application.dto.event;
 import java.util.UUID;
 
 public record ReservationFailedEvent(
-        UUID productId,
+        UUID Id,
         String reason
 ) {}

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -6,6 +6,7 @@ import org.pgsg.common.event.Events;
 import org.pgsg.common.event.OutboxEvent;
 import org.pgsg.reservation.application.dto.event.ReservationCancelledEvent;
 import org.pgsg.reservation.application.dto.event.ReservationCompletedEvent;
+import org.pgsg.reservation.application.dto.event.ReservationFailedEvent;
 import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublisher;
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +25,9 @@ public class ReservationEventBridge implements ReservationEventPublisher {
     @Value("${topics.reservation.cancelled}")
     private String buyerCancelledTopicName;
 
+    @Value("${topics.reservation.failed}")
+    private String failureTopicName;
+
     @Override
     public void publishReservationCompleted(Reservation reservation) {
         try {
@@ -39,11 +43,11 @@ public class ReservationEventBridge implements ReservationEventPublisher {
             ReservationCompletedEvent event = ReservationCompletedEvent.from(reservation);
 
             Events.trigger(new OutboxEvent(
-                    correlationId,    // 1. correlationId
-                    domainId,         // 2. domainId (UUID 타입)
-                    "RESERVATION",    // 3. domainType
-                    completedTopicName,        // 4. eventType (토픽명)
-                    event             // 5. payload
+                    correlationId,    // correlationId
+                    domainId,         // domainId (UUID 타입)
+                    "RESERVATION",    // domainType
+                    completedTopicName,// eventType (토픽명)
+                    event             // payload
             ));
 
             log.info("예약 완료 Outbox 등록 완료 - correlationId: {}", correlationId);
@@ -51,6 +55,33 @@ public class ReservationEventBridge implements ReservationEventPublisher {
         } catch (Exception e) {
             log.error("Outbox 등록 실패 - 예약 ID: {}", reservation.getId(), e);
             throw new RuntimeException("이벤트 발행 중 오류 발생", e);
+        }
+    }
+
+    // 상품 생성 실패시 상품에 이벤트 발송
+    public void publishReservationCreationFailed(UUID productId, String reason) {
+        try {
+            log.info("예약 생성 실패 Outbox 등록 시작 - 상품 ID: {}", productId);
+
+            // 엔티티가 없으므로 correlationId와 domainId 모두 productId를 활용하거나,
+            // 별도의 랜덤 UUID를 domainId로 생성합니다.
+            UUID correlationId = UUID.fromString(productId.toString());
+            UUID domainId = UUID.randomUUID(); // Outbox PK용
+
+            ReservationFailedEvent event = new ReservationFailedEvent(productId, reason);
+
+            Events.trigger(new OutboxEvent(
+                    correlationId,    // 상품 서비스가 식별할 ID
+                    domainId,         // Outbox 식별 ID
+                    "RESERVATION",
+                    failureTopicName, // 실패 전용 토픽
+                    event
+            ));
+
+            log.info("예약 생성 실패 Outbox 등록 완료 - productId: {}", productId);
+
+        } catch (Exception e) {
+            log.error("실패 알림 Outbox 등록 중 오류 발생 - 상품 ID: {}", productId, e);
         }
     }
 
@@ -81,5 +112,24 @@ public class ReservationEventBridge implements ReservationEventPublisher {
             log.error("취소 Outbox 등록 실패 - 예약 ID: {}", reservation.getId(), e);
             throw new RuntimeException("취소 이벤트 발행 중 오류 발생", e);
         }
+    }
+
+    // 거래 완료 생성 실패시 발송하는 이벤트
+    public void publishTradeConfirmFailed(UUID reservationId, String reason) {
+        log.info("예약 생성 실패 Outbox 등록 시작 - 예약 ID: {}", reservationId);
+
+        UUID correlationId = UUID.fromString(reservationId.toString());
+        UUID domainId = UUID.randomUUID();
+
+        // 실패 전용 DTO: ReservationFailedEvent
+        ReservationFailedEvent event = new ReservationFailedEvent(correlationId, reason);
+
+        Events.trigger(new OutboxEvent(
+                correlationId,
+                domainId,
+                "TRADE", // 도메인 타입 구분
+                "prod-trade-rollback", // 거래 서비스가 구독할 토픽명
+                event
+        ));
     }
 }

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -88,6 +88,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
 
         } catch (Exception e) {
             log.error("실패 알림 Outbox 등록 중 오류 발생 - 상품 ID: {}", productId, e);
+            throw new RuntimeException("예약 생성 실패 이벤트 발행 중 오류 발생", e);
         }
     }
 

--- a/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/event/ReservationEventBridge.java
@@ -11,6 +11,8 @@ import org.pgsg.reservation.infrastructure.listener.dto.ReservationEventPublishe
 import org.pgsg.reservation.domain.model.reservation.Reservation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -25,8 +27,11 @@ public class ReservationEventBridge implements ReservationEventPublisher {
     @Value("${topics.reservation.cancelled}")
     private String buyerCancelledTopicName;
 
+    @Value("${topics.product.failed}")
+    private String productFailureTopicName;
+
     @Value("${topics.reservation.failed}")
-    private String failureTopicName;
+    private String tradeFailureTopicName;
 
     @Override
     public void publishReservationCompleted(Reservation reservation) {
@@ -59,6 +64,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
     }
 
     // 상품 생성 실패시 상품에 이벤트 발송
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void publishReservationCreationFailed(UUID productId, String reason) {
         try {
             log.info("예약 생성 실패 Outbox 등록 시작 - 상품 ID: {}", productId);
@@ -74,7 +80,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
                     correlationId,    // 상품 서비스가 식별할 ID
                     domainId,         // Outbox 식별 ID
                     "RESERVATION",
-                    failureTopicName, // 실패 전용 토픽
+                    productFailureTopicName, // 실패 전용 토픽
                     event
             ));
 
@@ -115,6 +121,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
     }
 
     // 거래 완료 생성 실패시 발송하는 이벤트
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void publishTradeConfirmFailed(UUID reservationId, String reason) {
         log.info("예약 생성 실패 Outbox 등록 시작 - 예약 ID: {}", reservationId);
 
@@ -128,7 +135,7 @@ public class ReservationEventBridge implements ReservationEventPublisher {
                 correlationId,
                 domainId,
                 "TRADE", // 도메인 타입 구분
-                "prod-trade-rollback", // 거래 서비스가 구독할 토픽명
+                tradeFailureTopicName, // 거래 서비스가 구독할 토픽명
                 event
         ));
     }

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ProductListener.java
@@ -12,6 +12,9 @@ import org.pgsg.reservation.domain.exception.ReservationErrorCode;
 import org.pgsg.reservation.domain.exception.ReservationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.pgsg.reservation.infrastructure.event.ReservationEventBridge;
+
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -20,6 +23,7 @@ public class ProductListener {
 
     private final ReservationService reservationService;
     private final ObjectMapper objectMapper;
+    private final ReservationEventBridge eventBridge;
 
     /**
      * 상품 서비스에서 타임딜 상품이 생성되었을 때의 이벤트를 수신합니다.
@@ -42,15 +46,18 @@ public class ProductListener {
             reservationService.createReservation(command);
         }catch (ReservationException e) {
             if (e.getErrorCode() == ReservationErrorCode.ALREADY_EXISTS) {
-                log.info("중복 예약 생성 이벤트 무시: productId={}",
-                        (event != null) ? event.productId() : "Unknown");
+                log.info("중복 예약 생성 이벤트 무시 (이미 존재): productId={}", Objects.requireNonNull(event).productId());
                 return;
             }
-            log.error("예약 생성 중 비즈니스 오류 발생: {}", e.getMessage());
-            throw e; // 재시도가 필요한 경우 던짐
+
+            log.error("예약 생성 비즈니스 실패: {}", e.getMessage());
+            eventBridge.publishReservationCreationFailed(Objects.requireNonNull(event).productId(), e.getMessage());
+
         } catch (Exception e) {
-            log.error("상품 생성 이벤트 처리 실패 - Topic: {}, Error: {}",
-                    record.topic(), e.getMessage());
+            log.error("시스템 장애로 인한 예약 생성 실패: {}", e.getMessage());
+            if (event != null) {
+                eventBridge.publishReservationCreationFailed(event.productId(), "SYSTEM_ERROR: " + e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
@@ -1,5 +1,6 @@
 package org.pgsg.reservation.infrastructure.listener;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,9 +37,17 @@ public class ReservationEventListener {
             groupId = "reservation-group"
     )
     public void handleTradeCompleted(ConsumerRecord<String, String> record) {
-        TradeCompletedEvent event = null;
+        TradeCompletedEvent event;
+        UUID reservationId = null;
         try {
-            event = objectMapper.readValue(record.value(), TradeCompletedEvent.class);
+            JsonNode root = objectMapper.readTree(record.value());
+            try {
+                reservationId = UUID.fromString(root.get("reservationId").asText());
+            } catch (IllegalArgumentException e) {
+                log.warn("유효하지 않은 UUID 형식의 reservationId 수신: {}", root.get("reservationId").asText());
+            }
+            event = objectMapper.treeToValue(root, TradeCompletedEvent.class);
+
             log.info("거래 완료 이벤트 수신 - Trade ID: {}, Reservation ID: {}",
                     event.tradeId(), event.reservationId());
 
@@ -53,16 +62,16 @@ public class ReservationEventListener {
             log.info("예약 확정 처리 성공 - Reservation ID: {}", event.reservationId());
         }catch (Exception e) {
             log.error("예약 확정 처리 실패 - Reservation ID: {}, Error: {}",
-                    (event != null) ? event.reservationId() : "Unknown", e.getMessage());
+                    (reservationId != null) ? reservationId : "Unknown", e.getMessage());
 
             // 실패 알림 발송
             // 이 알림을 보고 거래 서비스나 관리자 서비스가 후속 조치(거래 롤백 등)를 할 수 있습니다.
-            if (event != null) {
+            if (reservationId != null) {
                 // 사실 여기서는 productId를 알기 어려울 수 있으니,
                 // 브릿지에 reservationId를 받는 실패 메서드를 하나 더 만들거나
                 // event에서 productId를 꺼낼 수 있도록 설계하는 것이 좋을 수도?
                 bridge.publishTradeConfirmFailed(
-                        event.reservationId(), // UUID 타입
+                        reservationId, // UUID 타입
                         "CONFIRM_FAIL: " + e.getMessage()
                 );
             }

--- a/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
+++ b/src/main/java/org/pgsg/reservation/infrastructure/listener/ReservationEventListener.java
@@ -8,6 +8,7 @@ import org.pgsg.common.messaging.annotation.IdempotentConsumer;
 import org.pgsg.reservation.application.dto.command.ReservationConfirmCommand;
 import org.pgsg.reservation.application.service.ReservationService;
 import org.pgsg.reservation.infrastructure.listener.dto.TradeCompletedEvent;
+import org.pgsg.reservation.infrastructure.event.ReservationEventBridge;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,7 @@ public class ReservationEventListener {
 
     private final ReservationService reservationService;
     private final ObjectMapper objectMapper;
+    private final ReservationEventBridge bridge;
 
     private static final UUID SYSTEM_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     private static final String SYSTEM_ROLE = "ADMIN";
@@ -34,9 +36,9 @@ public class ReservationEventListener {
             groupId = "reservation-group"
     )
     public void handleTradeCompleted(ConsumerRecord<String, String> record) {
-
+        TradeCompletedEvent event = null;
         try {
-            TradeCompletedEvent event = objectMapper.readValue(record.value(), TradeCompletedEvent.class);
+            event = objectMapper.readValue(record.value(), TradeCompletedEvent.class);
             log.info("거래 완료 이벤트 수신 - Trade ID: {}, Reservation ID: {}",
                     event.tradeId(), event.reservationId());
 
@@ -51,7 +53,19 @@ public class ReservationEventListener {
             log.info("예약 확정 처리 성공 - Reservation ID: {}", event.reservationId());
         }catch (Exception e) {
             log.error("예약 확정 처리 실패 - Reservation ID: {}, Error: {}",
-                    record.topic(), e.getMessage());
+                    (event != null) ? event.reservationId() : "Unknown", e.getMessage());
+
+            // 실패 알림 발송
+            // 이 알림을 보고 거래 서비스나 관리자 서비스가 후속 조치(거래 롤백 등)를 할 수 있습니다.
+            if (event != null) {
+                // 사실 여기서는 productId를 알기 어려울 수 있으니,
+                // 브릿지에 reservationId를 받는 실패 메서드를 하나 더 만들거나
+                // event에서 productId를 꺼낼 수 있도록 설계하는 것이 좋을 수도?
+                bridge.publishTradeConfirmFailed(
+                        event.reservationId(), // UUID 타입
+                        "CONFIRM_FAIL: " + e.getMessage()
+                );
+            }
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,7 @@ topics:
   reservation:
     completed: prod-reservation-completed
     cancelled: prod-reservation-cancelled
-    failed: prod-product-failed
+    failed : prod-reservation-tradefail
   product:
     created: prod-product-created
+    failed: prod-product-failed

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,5 +71,6 @@ topics:
   reservation:
     completed: prod-reservation-completed
     cancelled: prod-reservation-cancelled
+    failed: prod-product-failed
   product:
     created: prod-product-created


### PR DESCRIPTION
### 작업 배경
- 이벤트 저장 실패시 실패 이벤트 발송

### 작업 내용
- trade,product listener부분에 실패시 이벤트 발송 처리 부분 구현
- ReservationEventBridge에 실패 이벤트 발송 처리 구현

### 테스트 여부
- 데이터 전송 확인 및 토픽 생성 확인하였습니다

### 기타

### 이슈
>  This closes #42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 생성 및 거래 확인 실패 이벤트 발행 기능 추가
  * 실패 발생 시 상세 오류 메시지와 함께 추적 가능한 이벤트 생성

* **버그 수정**
  * 이벤트 처리 중 발생하는 예외에 대한 안정적인 오류 처리 개선
  * 실패 이벤트 발행을 통한 시스템 신뢰성 및 운영 추적성 강화

* **구성**
  * 실패 이벤트 처리를 위한 새로운 메시지 큐 토픽 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/reservation-service/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->